### PR TITLE
Implement product search page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import Navbar from './components/Navbar';
 import Home from './pages/Home';
 import Placeholder from './pages/Placeholder';
+import ProductSearch from './pages/ProductSearch';
 
 const App: React.FC = () => {
   return (
@@ -10,8 +11,8 @@ const App: React.FC = () => {
       <Navbar />
       <Routes>
         <Route path="/" element={<Home />} />
-        <Route path="/search" element={<Placeholder title="Search" />} />
-        <Route path="/products" element={<Placeholder title="Products" />} />
+        <Route path="/search" element={<ProductSearch />} />
+        <Route path="/products" element={<ProductSearch />} />
         <Route path="/pantry/setup" element={<Placeholder title="SmartPantry Setup" />} />
         <Route path="/gift" element={<Placeholder title="GiftGenius" />} />
         <Route path="/cart" element={<Placeholder title="Cart" />} />

--- a/frontend/src/components/ProductCard.tsx
+++ b/frontend/src/components/ProductCard.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { Product } from '../mockProducts';
+
+interface Props {
+  product: Product;
+  onAddToCart: (id: number) => void;
+}
+
+const ProductCard: React.FC<Props> = ({ product, onAddToCart }) => {
+  return (
+    <div className="border rounded-lg overflow-hidden flex flex-col">
+      <img
+        src={product.image}
+        alt={product.title}
+        className="w-full h-40 object-cover"
+      />
+      <div className="p-4 flex flex-col flex-grow">
+        <h3 className="font-semibold mb-2">{product.title}</h3>
+        <p className="text-gray-700 mb-2">${product.price.toFixed(2)}</p>
+        {product.rating && (
+          <p className="text-yellow-600 text-sm mb-2">Rating: {product.rating}</p>
+        )}
+        <button
+          onClick={() => onAddToCart(product.id)}
+          className="mt-auto bg-blue-600 text-white px-3 py-1 rounded hover:bg-blue-700"
+        >
+          Add to Cart
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default ProductCard;

--- a/frontend/src/mockProducts.ts
+++ b/frontend/src/mockProducts.ts
@@ -1,0 +1,91 @@
+export interface Product {
+  id: number;
+  title: string;
+  price: number;
+  rating: number;
+  category: string;
+  image: string;
+}
+
+export const mockProducts: Product[] = [
+  {
+    id: 1,
+    title: 'Organic Apples',
+    price: 3.99,
+    rating: 4.5,
+    category: 'grocery',
+    image: 'https://via.placeholder.com/300?text=Apples'
+  },
+  {
+    id: 2,
+    title: 'Wireless Headphones',
+    price: 59.99,
+    rating: 4.2,
+    category: 'electronics',
+    image: 'https://via.placeholder.com/300?text=Headphones'
+  },
+  {
+    id: 3,
+    title: 'Smart LED TV',
+    price: 399.99,
+    rating: 4.6,
+    category: 'electronics',
+    image: 'https://via.placeholder.com/300?text=TV'
+  },
+  {
+    id: 4,
+    title: 'Comforter Set',
+    price: 79.99,
+    rating: 4.3,
+    category: 'home',
+    image: 'https://via.placeholder.com/300?text=Comforter'
+  },
+  {
+    id: 5,
+    title: 'Action Figure',
+    price: 14.99,
+    rating: 4.1,
+    category: 'toys',
+    image: 'https://via.placeholder.com/300?text=Action+Figure'
+  },
+  {
+    id: 6,
+    title: 'Women\'s Sneakers',
+    price: 49.99,
+    rating: 4.4,
+    category: 'fashion',
+    image: 'https://via.placeholder.com/300?text=Sneakers'
+  },
+  {
+    id: 7,
+    title: 'Yoga Mat',
+    price: 19.99,
+    rating: 4.7,
+    category: 'sports',
+    image: 'https://via.placeholder.com/300?text=Yoga+Mat'
+  },
+  {
+    id: 8,
+    title: 'Blender',
+    price: 29.99,
+    rating: 4.0,
+    category: 'home',
+    image: 'https://via.placeholder.com/300?text=Blender'
+  },
+  {
+    id: 9,
+    title: 'Kids T-shirt',
+    price: 9.99,
+    rating: 4.3,
+    category: 'fashion',
+    image: 'https://via.placeholder.com/300?text=Kids+Tshirt'
+  },
+  {
+    id: 10,
+    title: 'Chocolate Cookies',
+    price: 2.99,
+    rating: 4.8,
+    category: 'grocery',
+    image: 'https://via.placeholder.com/300?text=Cookies'
+  }
+];

--- a/frontend/src/pages/ProductSearch.tsx
+++ b/frontend/src/pages/ProductSearch.tsx
@@ -1,0 +1,70 @@
+import React, { useEffect } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import ProductCard from '../components/ProductCard';
+import { mockProducts } from '../mockProducts';
+
+const ProductSearch: React.FC = () => {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const query = searchParams.get('q')?.toLowerCase() || '';
+  const category = searchParams.get('category')?.toLowerCase() || '';
+
+  useEffect(() => {
+    if (query) {
+      console.log(`Searching for: ${query}`);
+    }
+    if (category) {
+      console.log(`Filtering category: ${category}`);
+    }
+  }, [query, category]);
+
+  const handleCategoryChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const value = e.target.value;
+    const params: Record<string, string> = {};
+    if (value) params['category'] = value;
+    if (query) params['q'] = query;
+    setSearchParams(params);
+  };
+
+  const products = mockProducts.filter((p) => {
+    const matchesQuery = query ? p.title.toLowerCase().includes(query) : true;
+    const matchesCategory = category ? p.category.toLowerCase() === category : true;
+    return matchesQuery && matchesCategory;
+  });
+
+  const categories = Array.from(new Set(mockProducts.map((p) => p.category)));
+
+  const addToCart = (id: number) => {
+    console.log(`Add to cart: ${id}`);
+  };
+
+  return (
+    <div className="max-w-7xl mx-auto p-4">
+      <div className="flex justify-between items-center mb-4">
+        <h1 className="text-2xl font-bold">Products</h1>
+        <select
+          value={category}
+          onChange={handleCategoryChange}
+          className="border p-2 rounded"
+        >
+          <option value="">All Categories</option>
+          {categories.map((c) => (
+            <option key={c} value={c}>
+              {c.charAt(0).toUpperCase() + c.slice(1)}
+            </option>
+          ))}
+        </select>
+      </div>
+      {products.length === 0 ? (
+        <p>No products found for your search</p>
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+          {products.map((product) => (
+            <ProductCard key={product.id} product={product} onAddToCart={addToCart} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ProductSearch;


### PR DESCRIPTION
## Summary
- create mock product data
- build `<ProductCard>` component
- implement `/search` and `/products` pages to filter products by query params
- wire routes to new page

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68650930e74083219b766d578dff3ecb