### PR TITLE
Add cart page and context

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import Navbar from './components/Navbar';
 import Home from './pages/Home';
 import Placeholder from './pages/Placeholder';
 import ProductSearch from './pages/ProductSearch';
+import CartPage from './pages/CartPage';
 
 const App: React.FC = () => {
   return (
@@ -15,7 +16,7 @@ const App: React.FC = () => {
         <Route path="/products" element={<ProductSearch />} />
         <Route path="/pantry/setup" element={<Placeholder title="SmartPantry Setup" />} />
         <Route path="/gift" element={<Placeholder title="GiftGenius" />} />
-        <Route path="/cart" element={<Placeholder title="Cart" />} />
+        <Route path="/cart" element={<CartPage />} />
         <Route path="/profile" element={<Placeholder title="Profile" />} />
       </Routes>
     </Router>

--- a/frontend/src/components/ProductCard.tsx
+++ b/frontend/src/components/ProductCard.tsx
@@ -3,7 +3,7 @@ import { Product } from '../mockProducts';
 
 interface Props {
   product: Product;
-  onAddToCart: (id: number) => void;
+  onAddToCart: (product: Product) => void;
 }
 
 const ProductCard: React.FC<Props> = ({ product, onAddToCart }) => {
@@ -21,7 +21,7 @@ const ProductCard: React.FC<Props> = ({ product, onAddToCart }) => {
           <p className="text-yellow-600 text-sm mb-2">Rating: {product.rating}</p>
         )}
         <button
-          onClick={() => onAddToCart(product.id)}
+          onClick={() => onAddToCart(product)}
           className="mt-auto bg-blue-600 text-white px-3 py-1 rounded hover:bg-blue-700"
         >
           Add to Cart

--- a/frontend/src/context/CartContext.tsx
+++ b/frontend/src/context/CartContext.tsx
@@ -1,0 +1,56 @@
+import React, { createContext, useContext, useState } from 'react';
+import { Product } from '../mockProducts';
+
+type CartItem = {
+  product: Product;
+  quantity: number;
+};
+
+interface CartContextProps {
+  items: CartItem[];
+  addItem: (product: Product) => void;
+  updateQuantity: (productId: number, quantity: number) => void;
+  removeItem: (productId: number) => void;
+}
+
+const CartContext = createContext<CartContextProps | undefined>(undefined);
+
+export const useCart = (): CartContextProps => {
+  const ctx = useContext(CartContext);
+  if (!ctx) throw new Error('useCart must be used within CartProvider');
+  return ctx;
+};
+
+export const CartProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [items, setItems] = useState<CartItem[]>([]);
+
+  const addItem = (product: Product) => {
+    setItems((prev) => {
+      const existing = prev.find((i) => i.product.id === product.id);
+      if (existing) {
+        return prev.map((i) =>
+          i.product.id === product.id ? { ...i, quantity: i.quantity + 1 } : i
+        );
+      }
+      return [...prev, { product, quantity: 1 }];
+    });
+  };
+
+  const updateQuantity = (productId: number, quantity: number) => {
+    setItems((prev) =>
+      prev.map((i) =>
+        i.product.id === productId ? { ...i, quantity } : i
+      )
+    );
+  };
+
+  const removeItem = (productId: number) => {
+    setItems((prev) => prev.filter((i) => i.product.id !== productId));
+  };
+
+  return (
+    <CartContext.Provider value={{ items, addItem, updateQuantity, removeItem }}>
+      {children}
+    </CartContext.Provider>
+  );
+};

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
+import { CartProvider } from './context/CartContext';
 import reportWebVitals from './reportWebVitals';
 
 const root = ReactDOM.createRoot(
@@ -9,7 +10,9 @@ const root = ReactDOM.createRoot(
 );
 root.render(
   <React.StrictMode>
-    <App />
+    <CartProvider>
+      <App />
+    </CartProvider>
   </React.StrictMode>
 );
 

--- a/frontend/src/pages/CartPage.tsx
+++ b/frontend/src/pages/CartPage.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { useCart } from '../context/CartContext';
+
+const CartPage: React.FC = () => {
+  const { items, updateQuantity, removeItem } = useCart();
+
+  const subtotal = items.reduce(
+    (sum, item) => sum + item.product.price * item.quantity,
+    0
+  );
+
+  const handleCheckout = () => {
+    console.log('Checkout initiated');
+    console.log('Subtotal:', subtotal.toFixed(2));
+    console.log('Items:', items);
+  };
+
+  if (items.length === 0) {
+    return <div className="p-4">Your cart is empty.</div>;
+  }
+
+  return (
+    <div className="max-w-4xl mx-auto p-4">
+      <h1 className="text-2xl font-bold mb-4">Your Cart</h1>
+      <div className="space-y-4">
+        {items.map((item) => (
+          <div
+            key={item.product.id}
+            className="flex items-center border p-4 rounded"
+          >
+            <img
+              src={item.product.image}
+              alt={item.product.title}
+              className="w-20 h-20 object-cover mr-4"
+            />
+            <div className="flex-1">
+              <h2 className="font-semibold">{item.product.title}</h2>
+              <p>${item.product.price.toFixed(2)}</p>
+            </div>
+            <input
+              type="number"
+              min={1}
+              value={item.quantity}
+              onChange={(e) =>
+                updateQuantity(item.product.id, Number(e.target.value))
+              }
+              className="border w-16 p-1 mr-2 rounded"
+            />
+            <button
+              onClick={() => removeItem(item.product.id)}
+              className="bg-red-500 text-white px-3 py-1 rounded"
+            >
+              Remove
+            </button>
+          </div>
+        ))}
+      </div>
+      <div className="mt-6 text-right">
+        <p className="text-lg font-semibold mb-2">
+          Subtotal: ${subtotal.toFixed(2)}
+        </p>
+        <button
+          onClick={handleCheckout}
+          className="bg-green-600 text-white px-4 py-2 rounded"
+        >
+          Checkout
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default CartPage;

--- a/frontend/src/pages/ProductSearch.tsx
+++ b/frontend/src/pages/ProductSearch.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import ProductCard from '../components/ProductCard';
-import { mockProducts } from '../mockProducts';
+import { mockProducts, Product } from '../mockProducts';
+import { useCart } from '../context/CartContext';
 
 const ProductSearch: React.FC = () => {
   const [searchParams, setSearchParams] = useSearchParams();
@@ -33,8 +34,10 @@ const ProductSearch: React.FC = () => {
 
   const categories = Array.from(new Set(mockProducts.map((p) => p.category)));
 
-  const addToCart = (id: number) => {
-    console.log(`Add to cart: ${id}`);
+  const { addItem } = useCart();
+
+  const addToCart = (product: Product) => {
+    addItem(product);
   };
 
   return (


### PR DESCRIPTION
## Summary
- create CartContext for global cart state
- implement CartPage with item management and checkout log
- update ProductCard to add products to cart
- connect ProductSearch with cart context
- wrap app in CartProvider and add /cart route

## Testing
- `npm run build --silent`

------
https://chatgpt.com/codex/tasks/task_e_68650be4c29c832197c18ad60bfef105