### PR TITLE
Add solo gift suggestions

### DIFF
--- a/frontend/src/mockGiftGenius.ts
+++ b/frontend/src/mockGiftGenius.ts
@@ -1,4 +1,4 @@
-import { mockProducts } from './mockProducts';
+import { mockProducts, Product } from './mockProducts';
 
 export interface GiftBundle {
   title: string;
@@ -6,7 +6,12 @@ export interface GiftBundle {
   totalPrice: number;
 }
 
-export const mockGiftGenius = async (prompt: string): Promise<GiftBundle[]> => {
+export interface GiftSuggestions {
+  bundles: GiftBundle[];
+  items: Product[];
+}
+
+export const mockGiftGenius = async (prompt: string): Promise<GiftSuggestions> => {
   console.log('mockGiftGenius called with prompt:', prompt);
   return new Promise((resolve) => {
     setTimeout(() => {
@@ -31,7 +36,19 @@ export const mockGiftGenius = async (prompt: string): Promise<GiftBundle[]> => {
           totalPrice: parseFloat(total.toFixed(2)),
         });
       }
-      resolve(bundles);
+
+      // Generate solo item recommendations
+      const numSolo = 2 + Math.floor(Math.random() * 3); // 2-4 items
+      const soloItems: Product[] = [];
+      const chosenSoloIndexes = new Set<number>();
+      while (soloItems.length < numSolo) {
+        const index = Math.floor(Math.random() * mockProducts.length);
+        if (chosenSoloIndexes.has(index)) continue;
+        chosenSoloIndexes.add(index);
+        soloItems.push(mockProducts[index]);
+      }
+
+      resolve({ bundles, items: soloItems });
     }, 1000);
   });
 };

--- a/frontend/src/pages/GiftGenius.tsx
+++ b/frontend/src/pages/GiftGenius.tsx
@@ -1,9 +1,11 @@
 import React, { useState } from 'react';
-import { GiftBundle, mockGiftGenius } from '../mockGiftGenius';
+import { GiftBundle, GiftSuggestions, mockGiftGenius } from '../mockGiftGenius';
+import { Product } from '../mockProducts';
 
 interface ChatEntry {
   prompt: string;
   bundles: GiftBundle[];
+  items: Product[];
 }
 
 const GiftGenius: React.FC = () => {
@@ -16,9 +18,9 @@ const GiftGenius: React.FC = () => {
     console.log('User prompt:', prompt);
     setLoading(true);
     try {
-      const bundles = await mockGiftGenius(prompt);
-      console.log('LLM response:', bundles);
-      setHistory((prev) => [...prev, { prompt, bundles }]);
+      const result: GiftSuggestions = await mockGiftGenius(prompt);
+      console.log('LLM response:', result);
+      setHistory((prev) => [...prev, { prompt, bundles: result.bundles, items: result.items }]);
       setPrompt('');
     } finally {
       setLoading(false);
@@ -37,6 +39,15 @@ const GiftGenius: React.FC = () => {
             <div className="bg-gray-100 p-2 rounded self-start">
               {entry.prompt}
             </div>
+
+            {entry.items.map((item, iIdx) => (
+              <div key={iIdx} className="bg-green-50 p-3 rounded">
+                <h3 className="font-semibold">{item.title}</h3>
+                <p className="text-sm">{item.description}</p>
+                <p className="font-medium mt-1">Price: ${item.price.toFixed(2)}</p>
+              </div>
+            ))}
+
             {entry.bundles.map((bundle, bIdx) => (
               <div key={bIdx} className="bg-blue-50 p-3 rounded">
                 <h3 className="font-semibold">{bundle.title}</h3>


### PR DESCRIPTION
## Summary
- expand mock data to return solo gift items with bundles
- display solo item suggestions in GiftGenius page

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68651df9b1108321b9ad204366e8fe2f