### PR TITLE
Make GiftGenius results clickable

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import ProductSearch from './pages/ProductSearch';
 import ProductDetail from './pages/ProductDetail';
 import CartPage from './pages/CartPage';
 import PantrySetup from './pages/PantrySetup';
+import GiftBundlePage from './pages/GiftBundlePage';
 import { CartProvider } from './context/CartContext';
 
 const App: React.FC = () => {
@@ -22,6 +23,7 @@ const App: React.FC = () => {
           <Route path="/product/:id" element={<ProductDetail />} />
           <Route path="/pantry/setup" element={<PantrySetup />} />
           <Route path="/gift" element={<GiftGenius />} />
+          <Route path="/bundle" element={<GiftBundlePage />} />
           <Route path="/cart" element={<CartPage />} />
           <Route path="/profile" element={<Profile />} />
         </Routes>

--- a/frontend/src/mockGiftGenius.ts
+++ b/frontend/src/mockGiftGenius.ts
@@ -2,7 +2,7 @@ import { mockProducts, Product } from './mockProducts';
 
 export interface GiftBundle {
   title: string;
-  items: string[];
+  items: Product[];
   totalPrice: number;
 }
 
@@ -19,7 +19,7 @@ export const mockGiftGenius = async (prompt: string): Promise<GiftSuggestions> =
       const bundles: GiftBundle[] = [];
       for (let i = 0; i < numBundles; i++) {
         const numItems = 3 + Math.floor(Math.random() * 3); // 3-5 items
-        const items: string[] = [];
+        const items: Product[] = [];
         const chosenIndexes = new Set<number>();
         let total = 0;
         while (items.length < numItems) {
@@ -27,7 +27,7 @@ export const mockGiftGenius = async (prompt: string): Promise<GiftSuggestions> =
           if (chosenIndexes.has(index)) continue;
           chosenIndexes.add(index);
           const prod = mockProducts[index];
-          items.push(prod.title);
+          items.push(prod);
           total += prod.price;
         }
         bundles.push({

--- a/frontend/src/pages/GiftBundlePage.tsx
+++ b/frontend/src/pages/GiftBundlePage.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { Link, useLocation } from 'react-router-dom';
+import { GiftBundle } from '../mockGiftGenius';
+
+const GiftBundlePage: React.FC = () => {
+  const location = useLocation();
+  const bundle = (location.state as { bundle?: GiftBundle } | undefined)?.bundle;
+
+  if (!bundle) {
+    return <div className="p-4">No bundle selected.</div>;
+  }
+
+  return (
+    <div className="max-w-2xl mx-auto p-4 space-y-4">
+      <h1 className="text-2xl font-bold">{bundle.title}</h1>
+      <ul className="space-y-2">
+        {bundle.items.map((item) => (
+          <li key={item.id} className="border p-3 rounded">
+            <Link to={`/product/${item.id}`} className="font-semibold hover:underline">
+              {item.title}
+            </Link>
+            <p className="text-sm">{item.description}</p>
+            <p className="font-medium">Price: ${item.price.toFixed(2)}</p>
+          </li>
+        ))}
+      </ul>
+      <p className="font-semibold">Bundle Total: ${bundle.totalPrice.toFixed(2)}</p>
+    </div>
+  );
+};
+
+export default GiftBundlePage;

--- a/frontend/src/pages/GiftGenius.tsx
+++ b/frontend/src/pages/GiftGenius.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { Link } from 'react-router-dom';
 import { GiftBundle, GiftSuggestions, mockGiftGenius } from '../mockGiftGenius';
 import { Product } from '../mockProducts';
 
@@ -41,19 +42,28 @@ const GiftGenius: React.FC = () => {
             </div>
 
             {entry.items.map((item, iIdx) => (
-              <div key={iIdx} className="bg-green-50 p-3 rounded">
+              <Link
+                key={iIdx}
+                to={`/product/${item.id}`}
+                className="block bg-green-50 p-3 rounded hover:bg-green-100"
+              >
                 <h3 className="font-semibold">{item.title}</h3>
                 <p className="text-sm">{item.description}</p>
                 <p className="font-medium mt-1">Price: ${item.price.toFixed(2)}</p>
-              </div>
+              </Link>
             ))}
 
             {entry.bundles.map((bundle, bIdx) => (
-              <div key={bIdx} className="bg-blue-50 p-3 rounded">
+              <Link
+                to="/bundle"
+                state={{ bundle }}
+                key={bIdx}
+                className="block bg-blue-50 p-3 rounded hover:bg-blue-100"
+              >
                 <h3 className="font-semibold">{bundle.title}</h3>
                 <ul className="list-disc pl-5 text-sm">
                   {bundle.items.map((item) => (
-                    <li key={item}>{item}</li>
+                    <li key={item.id}>{item.title}</li>
                   ))}
                 </ul>
                 <p className="font-medium mt-1">
@@ -65,7 +75,7 @@ const GiftGenius: React.FC = () => {
                 >
                   Add All to Cart
                 </button>
-              </div>
+              </Link>
             ))}
           </div>
         ))}


### PR DESCRIPTION
## Summary
- adjust mockGiftGenius to return full product info in bundles
- link solo items to `ProductDetail` page
- add new page `GiftBundlePage` for viewing bundle contents
- wire up new bundle route

## Testing
- `npm install`
- `npm test -- -u`

------
https://chatgpt.com/codex/tasks/task_e_68651fa29310832194bfc982ab578d78