### PR TITLE
Add JWT login feature

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1,12 +1,27 @@
 import os
-from flask import Flask, jsonify
+from datetime import datetime, timedelta
+
+from flask import Flask, jsonify, request
 from flask_cors import CORS
 from dotenv import load_dotenv
+from flask_bcrypt import Bcrypt
+import jwt
+
+try:
+    from .models import db, User  # type: ignore
+except ImportError:
+    from models import db, User  # type: ignore
 
 load_dotenv()  # Load variables from .env
 
 app = Flask(__name__)
+app.config['SQLALCHEMY_DATABASE_URI'] = os.getenv('DATABASE_URL')
+app.config['SECRET_KEY'] = os.getenv('SECRET_KEY', 'dev-secret')
+app.config['JWT_EXPIRY_SECONDS'] = int(os.getenv('JWT_EXPIRY_SECONDS', '3600'))
+
 CORS(app)
+db.init_app(app)
+bcrypt = Bcrypt(app)
 
 @app.route("/")
 def hello():
@@ -14,6 +29,25 @@ def hello():
         "message": "SmartPantry backend running!",
         "openai_key_loaded": bool(os.getenv("OPENAI_API_KEY"))
     })
+
+
+@app.route("/api/login", methods=["POST"])
+def login():
+    data = request.get_json() or {}
+    email = data.get("email")
+    password = data.get("password")
+    if not email or not password:
+        return jsonify({"error": "Email and password required"}), 400
+
+    user = User.query.filter_by(email=email).first()
+    if user and bcrypt.check_password_hash(user.password_hash, password):
+        payload = {
+            "user_id": str(user.id),
+            "exp": datetime.utcnow() + timedelta(seconds=app.config["JWT_EXPIRY_SECONDS"]),
+        }
+        token = jwt.encode(payload, app.config["SECRET_KEY"], algorithm="HS256")
+        return jsonify({"token": token})
+    return jsonify({"error": "Invalid credentials"}), 401
 
 if __name__ == "__main__":
     app.run(debug=True)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,7 @@
+Flask
+Flask-Cors
+Flask-Bcrypt
+Flask-SQLAlchemy
+PyJWT
+python-dotenv
+psycopg2-binary

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,8 @@ import ProductDetail from './pages/ProductDetail';
 import CartPage from './pages/CartPage';
 import PantrySetup from './pages/PantrySetup';
 import GiftBundlePage from './pages/GiftBundlePage';
+import Login from './pages/Login';
+import Dashboard from './pages/Dashboard';
 import { CartProvider } from './context/CartContext';
 import { ToastContainer } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css'; // Import toast styling
@@ -42,6 +44,8 @@ const App: React.FC = () => {
           <Route path="/bundle" element={<GiftBundlePage />} />
           <Route path="/cart" element={<CartPage />} />
           <Route path="/profile" element={<Profile />} />
+          <Route path="/login" element={<Login />} />
+          <Route path="/dashboard" element={<Dashboard />} />
         </Routes>
       </Router>
     </CartProvider>

--- a/frontend/src/components/LoginForm.tsx
+++ b/frontend/src/components/LoginForm.tsx
@@ -1,0 +1,61 @@
+import React, { useState } from 'react';
+import axios from 'axios';
+import { useNavigate } from 'react-router-dom';
+import { toast } from 'react-toastify';
+
+const LoginForm: React.FC = () => {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [loading, setLoading] = useState(false);
+  const navigate = useNavigate();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (loading) return;
+    setLoading(true);
+    try {
+      const res = await axios.post('/api/login', { email, password });
+      localStorage.setItem('auth_token', res.data.token);
+      toast.success('Logged in');
+      navigate('/dashboard');
+    } catch (err: any) {
+      toast.error(err.response?.data?.error || 'Login failed');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4 bg-white p-6 rounded shadow">
+      <div>
+        <label className="block text-sm font-medium mb-1">Email</label>
+        <input
+          type="email"
+          className="w-full border rounded px-3 py-2"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+        />
+      </div>
+      <div>
+        <label className="block text-sm font-medium mb-1">Password</label>
+        <input
+          type="password"
+          className="w-full border rounded px-3 py-2"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          required
+        />
+      </div>
+      <button
+        type="submit"
+        disabled={loading}
+        className="w-full bg-primary-600 text-white py-2 rounded hover:bg-primary-700 disabled:opacity-50"
+      >
+        {loading ? 'Logging in...' : 'Login'}
+      </button>
+    </form>
+  );
+};
+
+export default LoginForm;

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -31,14 +31,20 @@ const Navbar: React.FC = () => {
               >
                 GiftGenius
               </Link>
-              <Link 
-                to="/cart" 
+              <Link
+                to="/cart"
                 className="px-3 py-2 rounded-md text-sm font-medium hover:bg-primary-500 hover:text-accent-300 transition-all"
               >
                 Cart
               </Link>
-              <Link 
-                to="/profile" 
+              <Link
+                to="/login"
+                className="px-3 py-2 rounded-md text-sm font-medium hover:bg-primary-500 hover:text-accent-300 transition-all"
+              >
+                Login
+              </Link>
+              <Link
+                to="/profile"
                 className="px-3 py-2 rounded-md text-sm font-medium hover:bg-primary-500 hover:text-accent-300 transition-all"
               >
                 Profile
@@ -85,15 +91,22 @@ const Navbar: React.FC = () => {
           >
             GiftGenius
           </Link>
-          <Link 
-            to="/cart" 
+          <Link
+            to="/cart"
             className="block px-3 py-2 rounded-md text-base font-medium hover:bg-primary-500 hover:text-accent-300 transition-all"
             onClick={() => setIsOpen(false)}
           >
             Cart
           </Link>
-          <Link 
-            to="/profile" 
+          <Link
+            to="/login"
+            className="block px-3 py-2 rounded-md text-base font-medium hover:bg-primary-500 hover:text-accent-300 transition-all"
+            onClick={() => setIsOpen(false)}
+          >
+            Login
+          </Link>
+          <Link
+            to="/profile"
             className="block px-3 py-2 rounded-md text-base font-medium hover:bg-primary-500 hover:text-accent-300 transition-all"
             onClick={() => setIsOpen(false)}
           >

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const Dashboard: React.FC = () => (
+  <div className="p-4">
+    <h1 className="text-2xl font-bold">Dashboard</h1>
+  </div>
+);
+
+export default Dashboard;

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import LoginForm from '../components/LoginForm';
+
+const Login: React.FC = () => (
+  <div className="flex items-center justify-center h-[calc(100vh-4rem)] p-4">
+    <div className="w-full max-w-sm">
+      <LoginForm />
+    </div>
+  </div>
+);
+
+export default Login;


### PR DESCRIPTION
## Summary
- implement `/api/login` route with JWT auth
- add backend requirements file
- create React login form and pages
- add login route and dashboard route to router
- link login from navbar

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npm install` *(fails: ENOTFOUND)*

------
https://chatgpt.com/codex/tasks/task_e_68653c1da0e0832199c5aec1f42275d6