### PR TITLE
Fix missing GiftBundle field

### DIFF
--- a/frontend/src/pages/GiftBundlePage.tsx
+++ b/frontend/src/pages/GiftBundlePage.tsx
@@ -51,7 +51,6 @@ const GiftBundlePage: React.FC = () => {
           <h1 className="text-2xl md:text-3xl font-bold text-primary-600 dark:text-primary-400 mb-2">
             {bundle.title}
           </h1>
-          <p className="text-gray-600 dark:text-gray-300">{bundle.description}</p>
         </div>
 
         <div className="p-6">


### PR DESCRIPTION
## Summary
- remove `bundle.description` use because GiftBundle doesn't have it

## Testing
- `npm test --silent -- --watchAll=false` *(fails: Jest encountered an unexpected token)*
- `npm run build --silent`

------
https://chatgpt.com/codex/tasks/task_e_6865eb8ea5308321bb6eebd6bb556610