### PR TITLE
Fix duplicate toast notifications

### DIFF
--- a/frontend/src/pages/CartPage.tsx
+++ b/frontend/src/pages/CartPage.tsx
@@ -88,7 +88,6 @@ const CartPage: React.FC = () => {
               <button
                 onClick={() => {
                   removeFromCart(item.id);
-                  toast.error('Item removed from cart');
                 }}
                 className="bg-red-500 hover:bg-red-600 text-white px-3 py-2 rounded-md transition-all"
               >
@@ -105,7 +104,6 @@ const CartPage: React.FC = () => {
           <button 
             onClick={() => {
               clearCart();
-              toast.error('Cart cleared');
             }}
             className="text-red-500 hover:text-red-600 text-sm font-medium transition-colors"
           >

--- a/frontend/src/pages/ProductDetail.tsx
+++ b/frontend/src/pages/ProductDetail.tsx
@@ -61,7 +61,6 @@ const ProductDetail: React.FC = () => {
   const handleAddToCart = () => {
     if (!product) return;
     addToCart(product);
-    toast.success(`${product.title} added to cart!`);
   };
 
   return (

--- a/frontend/src/pages/ProductSearch.tsx
+++ b/frontend/src/pages/ProductSearch.tsx
@@ -62,7 +62,6 @@ const ProductSearch: React.FC = () => {
 
   const handleAddToCart = (product: Product) => {
     addToCart(product);
-    toast.success(`${product.title} added to cart!`);
   };
 
   return (


### PR DESCRIPTION
## Summary
- stop redundant toast messages when adding items to cart
- stop redundant toast messages for cart item removal and clearing the cart

## Testing
- `npm test --silent` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_686783d5bda48321b1cd4bc2549b63ec