### PR TITLE
Persist quantity in Add to Cart buttons

### DIFF
--- a/frontend/src/components/AddToCartButton.tsx
+++ b/frontend/src/components/AddToCartButton.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { Product } from '../types';
+import { useCart } from '../context/CartContext';
+
+interface Props {
+  product: Product;
+}
+
+const AddToCartButton: React.FC<Props> = ({ product }) => {
+  const { cartItems, addToCart, updateQuantity, removeFromCart } = useCart();
+  const existing = cartItems.find((item) => item.id === product.id);
+  const qty = existing ? existing.quantity : 0;
+
+  const increment = (e: React.MouseEvent) => {
+    e.preventDefault();
+    if (existing) {
+      updateQuantity(product.id, existing.quantity + 1);
+    } else {
+      addToCart(product);
+    }
+  };
+
+  const decrement = (e: React.MouseEvent) => {
+    e.preventDefault();
+    if (!existing) return;
+    if (existing.quantity === 1) {
+      removeFromCart(product.id);
+    } else {
+      updateQuantity(product.id, existing.quantity - 1);
+    }
+  };
+
+  const handleAdd = (e: React.MouseEvent) => {
+    e.preventDefault();
+    addToCart(product);
+  };
+
+  if (!existing) {
+    return (
+      <button
+        onClick={handleAdd}
+        className="mt-auto bg-accent-400 hover:bg-accent-500 text-gray-900 px-4 py-2 rounded-md font-medium transition-all hover:scale-[1.02] active:scale-95"
+      >
+        Add to Cart
+      </button>
+    );
+  }
+
+  return (
+    <div className="mt-auto flex items-center space-x-2">
+      <button
+        onClick={decrement}
+        className="bg-gray-200 hover:bg-gray-300 text-gray-900 px-3 py-2 rounded-md"
+      >
+        -
+      </button>
+      <span className="min-w-[2ch] text-center">{qty}</span>
+      <button
+        onClick={increment}
+        className="bg-gray-200 hover:bg-gray-300 text-gray-900 px-3 py-2 rounded-md"
+      >
+        +
+      </button>
+    </div>
+  );
+};
+
+export default AddToCartButton;

--- a/frontend/src/components/ProductCard.tsx
+++ b/frontend/src/components/ProductCard.tsx
@@ -1,17 +1,13 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { Product } from '../types';
+import AddToCartButton from './AddToCartButton';
 
 interface Props {
   product: Product;
-  onAddToCart: (product: Product) => void;
 }
 
-const ProductCard: React.FC<Props> = ({ product, onAddToCart }) => {
-  const handleAddToCart = (e: React.MouseEvent<HTMLButtonElement>) => {
-    e.preventDefault();
-    onAddToCart(product);
-  };
+const ProductCard: React.FC<Props> = ({ product }) => {
 
   return (
     <Link
@@ -31,12 +27,7 @@ const ProductCard: React.FC<Props> = ({ product, onAddToCart }) => {
         <p className="text-primary-600 dark:text-primary-400 font-bold text-lg mb-2">
           ${product.price.toFixed(2)}
         </p>
-        <button
-          onClick={handleAddToCart}
-          className="mt-auto bg-accent-400 hover:bg-accent-500 text-gray-900 px-4 py-2 rounded-md font-medium transition-all hover:scale-[1.02] active:scale-95"
-        >
-          Add to Cart
-        </button>
+        <AddToCartButton product={product} />
       </div>
     </Link>
   );

--- a/frontend/src/pages/ProductDetail.tsx
+++ b/frontend/src/pages/ProductDetail.tsx
@@ -1,16 +1,11 @@
 import React, { useEffect, useState } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { Product } from '../types';
-import { useCart } from '../context/CartContext';
+import AddToCartButton from '../components/AddToCartButton';
 import api from '../api';
-
-
-
-import { toast } from 'react-toastify';
 
 const ProductDetail: React.FC = () => {
   const { id } = useParams<{ id: string }>();
-  const { addToCart } = useCart();
   const [product, setProduct] = useState<Product | null>(null);
   const [loading, setLoading] = useState(true);
 
@@ -58,10 +53,6 @@ const ProductDetail: React.FC = () => {
     );
   }
 
-  const handleAddToCart = () => {
-    if (!product) return;
-    addToCart(product);
-  };
 
   return (
     <div className="max-w-7xl mx-auto p-4 md:p-6">
@@ -105,12 +96,7 @@ const ProductDetail: React.FC = () => {
               {product.description}
             </p>
 
-            <button
-              onClick={handleAddToCart}
-              className="w-full bg-accent-400 hover:bg-accent-500 text-gray-900 px-6 py-3 rounded-md font-medium transition-all hover:scale-[1.02]"
-            >
-              Add to Cart
-            </button>
+            <AddToCartButton product={product} />
           </div>
         </div>
       </div>

--- a/frontend/src/pages/ProductList.tsx
+++ b/frontend/src/pages/ProductList.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useState } from 'react';
 import api from '../api';
 
 import { Product } from '../types';
+import ProductCard from '../components/ProductCard';
 
 const SkeletonCard: React.FC = () => (
   <div className="border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden shadow-sm animate-pulse">
@@ -10,32 +11,6 @@ const SkeletonCard: React.FC = () => (
     <div className="p-4 space-y-2">
       <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded w-3/4" />
       <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded w-1/2" />
-    </div>
-  </div>
-);
-
-const ProductCard: React.FC<{ product: Product }> = ({ product }) => (
-  <div className="group border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden shadow-sm hover:shadow-md transition-all bg-white dark:bg-gray-800">
-    <div className="relative">
-      <img
-        src={product.thumbnail}
-        alt={product.title}
-        className="w-full h-48 object-contain bg-white p-4"
-      />
-      {product.description && (
-        <div className="absolute inset-0 bg-white dark:bg-gray-800 bg-opacity-90 p-4 text-sm text-gray-700 dark:text-gray-300 opacity-0 group-hover:opacity-100 transition-opacity">
-          {product.description}
-        </div>
-      )}
-    </div>
-    <div className="p-4">
-      <h3 className="font-semibold text-gray-900 dark:text-white line-clamp-2">
-        {product.title}
-      </h3>
-      <p className="text-sm text-gray-500">{product.category}</p>
-      <p className="text-primary-600 dark:text-primary-400 font-bold mt-2">
-        ${product.price.toFixed(2)}
-      </p>
     </div>
   </div>
 );

--- a/frontend/src/pages/ProductSearch.tsx
+++ b/frontend/src/pages/ProductSearch.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import ProductCard from '../components/ProductCard';
 import { Product } from '../types';
-import { useCart } from '../context/CartContext';
 
 import api from '../api';
 
@@ -58,11 +57,6 @@ const ProductSearch: React.FC = () => {
 
   const categories = Array.from(new Set(products.map((p) => p.category)));
 
-  const { addToCart } = useCart();
-
-  const handleAddToCart = (product: Product) => {
-    addToCart(product);
-  };
 
   return (
     <div className="max-w-7xl mx-auto p-4 md:p-6">
@@ -106,11 +100,7 @@ const ProductSearch: React.FC = () => {
       ) : (
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
           {filtered.map((product) => (
-            <ProductCard 
-              key={product.id} 
-              product={product} 
-              onAddToCart={handleAddToCart} 
-            />
+            <ProductCard key={product.id} product={product} />
           ))}
         </div>
       )}


### PR DESCRIPTION
## Summary
- show quantity controls with `AddToCartButton`
- use the new button in `ProductCard`, product search/list pages and detail page
- keep quantity synced across pages via cart context

## Testing
- `npm test --silent` *(fails: Jest failed to run due to import issues)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6867899471f483218315a6a5900448c9