### PR TITLE
Fix double toast on remove

### DIFF
--- a/frontend/src/context/CartContext.tsx
+++ b/frontend/src/context/CartContext.tsx
@@ -61,13 +61,14 @@ export const CartProvider: React.FC<{ children: React.ReactNode }> = ({
   };
 
   const removeFromCart = (productId: number) => {
+    let removedProduct: ProductWithQty | undefined;
     setCartItems((prev) => {
-      const product = prev.find((p) => p.id === productId);
-        if (product) {
-          showToast(`Removed ${product.title} from cart`, 'error');
-        }
+      removedProduct = prev.find((p) => p.id === productId);
       return prev.filter((item) => item.id !== productId);
     });
+    if (removedProduct) {
+      showToast(`Removed ${removedProduct.title} from cart`, 'error');
+    }
   };
 
   const updateQuantity = (productId: number, qty: number) => {


### PR DESCRIPTION
## Summary
- prevent toast from firing twice when removing cart items

## Testing
- `npm test --silent -- -u` *(fails: SyntaxError: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68678d8ec39c83219fa7dc45880ec56f