### PR TITLE
Improve product details page

### DIFF
--- a/frontend/src/pages/ProductDetail.tsx
+++ b/frontend/src/pages/ProductDetail.tsx
@@ -8,6 +8,7 @@ const ProductDetail: React.FC = () => {
   const { id } = useParams<{ id: string }>();
   const [product, setProduct] = useState<Product | null>(null);
   const [loading, setLoading] = useState(true);
+  const [selectedImage, setSelectedImage] = useState<string>('');
 
   useEffect(() => {
     const fetchProduct = async () => {
@@ -17,6 +18,7 @@ const ProductDetail: React.FC = () => {
         const res = await api.get<Product>(`/api/products/${id}`);
 
         setProduct(res.data);
+        setSelectedImage(res.data.thumbnail || '');
       } catch (err) {
         console.error('Failed to fetch product', err);
       } finally {
@@ -68,12 +70,25 @@ const ProductDetail: React.FC = () => {
 
       <div className="bg-white dark:bg-gray-800 rounded-xl shadow-md overflow-hidden">
         <div className="flex flex-col md:flex-row">
-          <div className="md:w-1/2 bg-white p-6 flex items-center justify-center">
+          <div className="md:w-1/2 bg-white p-6 flex flex-col items-center justify-center">
             <img
-              src={product.thumbnail}
+              src={selectedImage || product.thumbnail}
               alt={product.title}
               className="w-full h-auto max-h-96 object-contain"
             />
+            {product.images && product.images.length > 0 && (
+              <div className="flex space-x-2 mt-4 overflow-x-auto">
+                {product.images.map((img) => (
+                  <img
+                    key={img}
+                    src={img}
+                    onClick={() => setSelectedImage(img)}
+                    className={`h-20 cursor-pointer border rounded-lg ${selectedImage === img ? 'border-primary-500' : 'border-transparent'}`}
+                    alt="thumbnail"
+                  />
+                ))}
+              </div>
+            )}
           </div>
           <div className="md:w-1/2 p-6 md:p-8">
             <div className="mb-4">
@@ -81,24 +96,89 @@ const ProductDetail: React.FC = () => {
                 {product.category}
               </span>
             </div>
-            
+
             <h1 className="text-2xl md:text-3xl font-bold text-gray-900 dark:text-white mb-4">
               {product.title}
             </h1>
-            
 
-
-            <p className="text-3xl font-bold text-primary-600 dark:text-primary-400 mb-6">
+            <p className="text-3xl font-bold text-primary-600 dark:text-primary-400 mb-4">
               ${product.price.toFixed(2)}
             </p>
 
-            <p className="text-gray-700 dark:text-gray-300 mb-8">
+            <p className="text-gray-700 dark:text-gray-300 mb-4">
               {product.description}
             </p>
+
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 text-sm mb-6">
+              {product.brand && (
+                <div><span className="font-medium">Brand:</span> {product.brand}</div>
+              )}
+              {product.sku && (
+                <div><span className="font-medium">SKU:</span> {product.sku}</div>
+              )}
+              {product.rating !== undefined && (
+                <div><span className="font-medium">Rating:</span> {product.rating}</div>
+              )}
+              {product.discountPercentage !== undefined && (
+                <div><span className="font-medium">Discount:</span> {product.discountPercentage}%</div>
+              )}
+              {product.stock !== undefined && (
+                <div><span className="font-medium">Stock:</span> {product.stock}</div>
+              )}
+              {product.weight !== undefined && (
+                <div><span className="font-medium">Weight:</span> {product.weight}</div>
+              )}
+              {product.dimensions && (
+                <div><span className="font-medium">Dimensions:</span> {product.dimensions.width}x{product.dimensions.height}x{product.dimensions.depth}</div>
+              )}
+              {product.warrantyInformation && (
+                <div><span className="font-medium">Warranty:</span> {product.warrantyInformation}</div>
+              )}
+              {product.shippingInformation && (
+                <div><span className="font-medium">Shipping:</span> {product.shippingInformation}</div>
+              )}
+              {product.availabilityStatus && (
+                <div><span className="font-medium">Availability:</span> {product.availabilityStatus}</div>
+              )}
+              {product.returnPolicy && (
+                <div><span className="font-medium">Return Policy:</span> {product.returnPolicy}</div>
+              )}
+              {product.minimumOrderQuantity !== undefined && (
+                <div><span className="font-medium">Min Order Qty:</span> {product.minimumOrderQuantity}</div>
+              )}
+              {product.tags && product.tags.length > 0 && (
+                <div className="sm:col-span-2"><span className="font-medium">Tags:</span> {product.tags.join(', ')}</div>
+              )}
+              {product.meta && (
+                <>
+                  <div><span className="font-medium">Barcode:</span> {product.meta.barcode}</div>
+                  <div><span className="font-medium">Created:</span> {new Date(product.meta.createdAt).toLocaleDateString()}</div>
+                  <div><span className="font-medium">Updated:</span> {new Date(product.meta.updatedAt).toLocaleDateString()}</div>
+                </>
+              )}
+            </div>
+
+            {product.meta?.qrCode && (
+              <img src={product.meta.qrCode} alt="QR Code" className="h-24 mb-4" />
+            )}
 
             <AddToCartButton product={product} />
           </div>
         </div>
+        {product.reviews && product.reviews.length > 0 && (
+          <div className="p-6 md:p-8 border-t border-gray-200 dark:border-gray-700">
+            <h2 className="text-xl font-semibold mb-4">Reviews</h2>
+            <div className="space-y-4">
+              {product.reviews.map((r, idx) => (
+                <div key={idx} className="bg-gray-50 dark:bg-gray-700 p-4 rounded-md">
+                  <p className="text-sm mb-1"><span className="font-medium">{r.reviewerName}</span> rated {r.rating}/5</p>
+                  <p className="text-xs text-gray-500 mb-2">{new Date(r.date).toLocaleDateString()}</p>
+                  <p>{r.comment}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,9 +1,45 @@
+export interface Dimensions {
+  width: number;
+  height: number;
+  depth: number;
+}
+
+export interface Meta {
+  createdAt: string;
+  updatedAt: string;
+  barcode: string;
+  qrCode: string;
+}
+
+export interface Review {
+  rating: number;
+  comment: string;
+  date: string;
+  reviewerName: string;
+  reviewerEmail: string;
+}
+
 export interface Product {
   id: number;
   title: string;
   description: string;
   price: number;
+  discountPercentage?: number;
+  rating?: number;
+  stock?: number;
+  brand?: string;
   category: string;
+  tags?: string[];
+  sku?: string;
+  weight?: number;
+  dimensions?: Dimensions;
+  warrantyInformation?: string;
+  shippingInformation?: string;
+  availabilityStatus?: string;
+  returnPolicy?: string;
+  minimumOrderQuantity?: number;
+  meta?: Meta;
   thumbnail: string;
   images: string[];
+  reviews?: Review[];
 }


### PR DESCRIPTION
## Summary
- expand `Product` type with optional fields from DummyJSON
- display all product fields in `ProductDetail` page including gallery and reviews

## Testing
- `npm test --silent` *(fails: SyntaxError: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68678da776c48321a595c1a02d8ad4f4