### PR TITLE
Implement basic registration

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -33,11 +33,11 @@ def ensure_user_schema() -> None:
         inspector = inspect(db.engine)
         if inspector.has_table("users"):
             columns = [c["name"] for c in inspector.get_columns("users")]
-            if "password_hash" not in columns:
+            if "hashed_password" not in columns:
                 with db.engine.begin() as conn:
                     conn.execute(
                         text(
-                            "ALTER TABLE users ADD COLUMN password_hash VARCHAR(255)"
+                            "ALTER TABLE users ADD COLUMN hashed_password VARCHAR(255)"
                         )
                     )
 
@@ -61,7 +61,7 @@ def login():
         return jsonify({"error": "Email and password required"}), 400
 
     user = User.query.filter_by(email=email).first()
-    if user and bcrypt.check_password_hash(user.password_hash, password):
+    if user and bcrypt.check_password_hash(user.hashed_password, password):
         payload = {
             "user_id": str(user.id),
             "exp": datetime.utcnow() + timedelta(seconds=app.config["JWT_EXPIRY_SECONDS"]),
@@ -76,25 +76,21 @@ def register():
     data = request.get_json() or {}
     email = data.get("email")
     password = data.get("password")
-    name = data.get("name")
 
     if not email or not password:
         return jsonify({"error": "Email and password required"}), 400
 
     if User.query.filter_by(email=email).first():
-        return jsonify({"error": "Email already registered"}), 400
+        return jsonify({"error": "Email already registered"}), 409
 
-    password_hash = bcrypt.generate_password_hash(password).decode("utf-8")
-    user = User(email=email, name=name, password_hash=password_hash)
+    hashed_password = bcrypt.generate_password_hash(password).decode("utf-8")
+    user = User(email=email, hashed_password=hashed_password)
     db.session.add(user)
     db.session.commit()
-
-    payload = {
-        "user_id": str(user.id),
-        "exp": datetime.utcnow() + timedelta(seconds=app.config["JWT_EXPIRY_SECONDS"]),
-    }
-    token = jwt.encode(payload, app.config["SECRET_KEY"], algorithm="HS256")
-    return jsonify({"token": token}), 201
+    return (
+        jsonify({"id": str(user.id), "email": user.email}),
+        201,
+    )
 
 @app.route("/api/products", methods=["GET"])
 def get_products():

--- a/backend/models.py
+++ b/backend/models.py
@@ -15,8 +15,7 @@ class User(db.Model):
 
     id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     email = db.Column(db.String(255), unique=True, nullable=False)
-    name = db.Column(db.String(120))
-    password_hash = db.Column(db.String(255))
+    hashed_password = db.Column(db.String(255), nullable=False)
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
     updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
 

--- a/frontend/src/components/RegisterForm.tsx
+++ b/frontend/src/components/RegisterForm.tsx
@@ -1,24 +1,19 @@
 import React, { useState } from 'react';
 import api from '../api';
-import { useNavigate } from 'react-router-dom';
 import { toast } from 'react-toastify';
 
 const RegisterForm: React.FC = () => {
-  const [name, setName] = useState('');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [loading, setLoading] = useState(false);
-  const navigate = useNavigate();
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (loading) return;
     setLoading(true);
     try {
-      const res = await api.post('/api/register', { name, email, password });
-      localStorage.setItem('auth_token', res.data.token);
+      await api.post('/api/register', { email, password });
       toast.success('Account created');
-      navigate('/dashboard');
     } catch (err: any) {
       toast.error(err.response?.data?.error || 'Registration failed');
     } finally {
@@ -28,16 +23,6 @@ const RegisterForm: React.FC = () => {
 
   return (
     <form onSubmit={handleSubmit} className="space-y-4 bg-white p-6 rounded shadow">
-      <div>
-        <label className="block text-sm font-medium mb-1">Name</label>
-        <input
-          type="text"
-          className="w-full border rounded px-3 py-2"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-          required
-        />
-      </div>
       <div>
         <label className="block text-sm font-medium mb-1">Email</label>
         <input


### PR DESCRIPTION
## Summary
- add hashed password field to the SQLAlchemy model
- add `/api/register` implementation using hashed passwords and duplicate email check
- simplify registration form to only require email and password

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6867a326cbb48321b2131b4ebc37b734