### PR TITLE
Implement basic registration

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -15,8 +15,7 @@ class User(db.Model):
 
     id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     email = db.Column(db.String(255), unique=True, nullable=False)
-    name = db.Column(db.String(120))
-    password_hash = db.Column(db.String(255))
+    hashed_password = db.Column(db.String(255), nullable=False)
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
     updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
 

--- a/frontend/src/components/RegisterForm.tsx
+++ b/frontend/src/components/RegisterForm.tsx
@@ -1,24 +1,19 @@
 import React, { useState } from 'react';
 import api from '../api';
-import { useNavigate } from 'react-router-dom';
 import { toast } from 'react-toastify';
 
 const RegisterForm: React.FC = () => {
-  const [name, setName] = useState('');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [loading, setLoading] = useState(false);
-  const navigate = useNavigate();
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (loading) return;
     setLoading(true);
     try {
-      const res = await api.post('/api/register', { name, email, password });
-      localStorage.setItem('auth_token', res.data.token);
+      await api.post('/api/register', { email, password });
       toast.success('Account created');
-      navigate('/dashboard');
     } catch (err: any) {
       toast.error(err.response?.data?.error || 'Registration failed');
     } finally {
@@ -28,16 +23,6 @@ const RegisterForm: React.FC = () => {
 
   return (
     <form onSubmit={handleSubmit} className="space-y-4 bg-white p-6 rounded shadow">
-      <div>
-        <label className="block text-sm font-medium mb-1">Name</label>
-        <input
-          type="text"
-          className="w-full border rounded px-3 py-2"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-          required
-        />
-      </div>
       <div>
         <label className="block text-sm font-medium mb-1">Email</label>
         <input


### PR DESCRIPTION
## Summary
- add hashed password field to the SQLAlchemy model
- add `/api/register` implementation using hashed passwords and duplicate email check
- simplify registration form to only require email and password
- create the users table automatically if it doesn't exist

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npm test --silent` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6867a326cbb48321b2131b4ebc37b734