### PR TITLE
Implement gift bundle chat with budget slider

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -8,6 +8,8 @@ from flask_bcrypt import Bcrypt
 import jwt
 import requests
 from sqlalchemy import inspect, text
+import random
+from typing import List, Dict, Optional
 
 try:
     from .models import db, User , Product # type: ignore
@@ -46,6 +48,103 @@ def ensure_user_schema() -> None:
 
 
 ensure_user_schema()
+
+# Sample product catalog used for mock gift bundle generation
+SAMPLE_PRODUCTS: List[Dict[str, any]] = [
+    {
+        "name": "Organic Apples",
+        "price": 3.99,
+        "imageUrl": "https://via.placeholder.com/300?text=Apples",
+        "description": "Crisp organic apples picked fresh from local farms.",
+    },
+    {
+        "name": "Wireless Headphones",
+        "price": 59.99,
+        "imageUrl": "https://via.placeholder.com/300?text=Headphones",
+        "description": "Bluetooth headphones with noise cancellation.",
+    },
+    {
+        "name": "Smart LED TV",
+        "price": 399.99,
+        "imageUrl": "https://via.placeholder.com/300?text=TV",
+        "description": "40-inch smart TV with built-in streaming apps.",
+    },
+    {
+        "name": "Comforter Set",
+        "price": 79.99,
+        "imageUrl": "https://via.placeholder.com/300?text=Comforter",
+        "description": "Plush queen-size comforter set to keep you cozy.",
+    },
+    {
+        "name": "Action Figure",
+        "price": 14.99,
+        "imageUrl": "https://via.placeholder.com/300?text=Action+Figure",
+        "description": "Collectible action figure with movable joints.",
+    },
+    {
+        "name": "Women's Sneakers",
+        "price": 49.99,
+        "imageUrl": "https://via.placeholder.com/300?text=Sneakers",
+        "description": "Comfortable sneakers perfect for everyday wear.",
+    },
+    {
+        "name": "Yoga Mat",
+        "price": 19.99,
+        "imageUrl": "https://via.placeholder.com/300?text=Yoga+Mat",
+        "description": "Non-slip yoga mat providing excellent grip.",
+    },
+    {
+        "name": "Blender",
+        "price": 29.99,
+        "imageUrl": "https://via.placeholder.com/300?text=Blender",
+        "description": "High-speed blender ideal for smoothies.",
+    },
+    {
+        "name": "Kids T-shirt",
+        "price": 9.99,
+        "imageUrl": "https://via.placeholder.com/300?text=Tshirt",
+        "description": "Soft cotton T-shirt with fun prints.",
+    },
+    {
+        "name": "Chocolate Cookies",
+        "price": 2.99,
+        "imageUrl": "https://via.placeholder.com/300?text=Cookies",
+        "description": "Rich chocolate chip cookies baked to perfection.",
+    },
+]
+
+
+def generate_mock_bundles(prompt: str, budget: Optional[float] = None) -> List[Dict]:
+    """Generate mock gift bundles."""
+    bundles: List[Dict] = []
+    num_bundles = random.randint(2, 3)
+
+    for idx in range(num_bundles):
+        num_items = random.randint(3, 5)
+        items = random.sample(SAMPLE_PRODUCTS, k=min(num_items, len(SAMPLE_PRODUCTS)))
+
+        total = sum(item["price"] for item in items)
+
+        if budget is not None:
+            # Remove expensive items until under budget
+            items_sorted = sorted(items, key=lambda i: i["price"])
+            while total > budget and len(items_sorted) > 1:
+                removed = items_sorted.pop()
+                total -= removed["price"]
+            items = items_sorted
+
+        bundles.append(
+            {
+                "title": f"Bundle {idx + 1}",
+                "items": items,
+                "totalPrice": round(total, 2),
+            }
+        )
+
+    if budget is not None:
+        bundles = [b for b in bundles if b["totalPrice"] <= budget * 1.05] or bundles
+
+    return bundles
 
 @app.route("/")
 def hello():
@@ -121,6 +220,23 @@ def get_product(product_id: int):
         return jsonify({"error": "Failed to fetch product"}), 500
 
     return jsonify(data)
+
+
+@app.route("/api/giftgenius/chat", methods=["POST"])
+def giftgenius_chat():
+    data = request.get_json() or {}
+    prompt = (data.get("prompt") or "").strip()
+    budget = data.get("budget")
+    if not prompt:
+        return jsonify({"error": "Prompt required"}), 400
+
+    try:
+        budget_val: Optional[float] = float(budget) if budget is not None else None
+    except (TypeError, ValueError):
+        budget_val = None
+
+    bundles = generate_mock_bundles(prompt, budget_val)
+    return jsonify({"bundles": bundles})
 
 if __name__ == "__main__":
     app.run(debug=True)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,7 +3,7 @@ import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import Navbar from './components/Navbar';
 import Home from './pages/Home';
 import ProfilePage from './pages/ProfilePage';
-import GiftGenius from './pages/GiftGenius';
+import GiftChatAssistant from './components/GiftChatAssistant';
 import ProductSearch from './pages/ProductSearch';
 import ProductList from './pages/ProductList';
 import ProductDetail from './pages/ProductDetail';
@@ -42,7 +42,7 @@ const App: React.FC = () => {
           <Route path="/products" element={<ProductList />} />
           <Route path="/product/:id" element={<ProductDetail />} />
           <Route path="/pantry/setup" element={<PantrySetup />} />
-          <Route path="/gift" element={<GiftGenius />} />
+          <Route path="/gift" element={<GiftChatAssistant />} />
           <Route path="/bundle" element={<GiftBundlePage />} />
           <Route path="/cart" element={<CartPage />} />
           <Route path="/profile" element={<ProfilePage />} />

--- a/frontend/src/components/BudgetSlider.tsx
+++ b/frontend/src/components/BudgetSlider.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+interface Props {
+  min: number;
+  max: number;
+  value: number;
+  onChange: (val: number) => void;
+}
+
+const BudgetSlider: React.FC<Props> = ({ min, max, value, onChange }) => {
+  return (
+    <div className="mb-4">
+      <label className="block mb-2 font-medium text-gray-900 dark:text-white">
+        Budget: ${value}
+      </label>
+      <input
+        type="range"
+        min={min}
+        max={max}
+        step={25}
+        value={value}
+        onChange={(e) => onChange(Number(e.target.value))}
+        className="w-full h-2 bg-gray-200 dark:bg-gray-700 rounded-lg appearance-none cursor-pointer accent-primary-600"
+      />
+      <div className="flex justify-between text-sm text-gray-500 dark:text-gray-400 mt-1">
+        <span>${min}</span>
+        <span>${max}</span>
+      </div>
+    </div>
+  );
+};
+
+export default BudgetSlider;

--- a/frontend/src/components/GiftBundleList.tsx
+++ b/frontend/src/components/GiftBundleList.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { GiftBundle } from '../types';
+
+interface Props {
+  bundles: GiftBundle[];
+}
+
+const GiftBundleList: React.FC<Props> = ({ bundles }) => {
+  return (
+    <div className="space-y-6">
+      {bundles.map((bundle, idx) => (
+        <div
+          key={idx}
+          className="border border-gray-200 dark:border-gray-700 rounded-lg p-4"
+        >
+          <h3 className="text-lg font-semibold text-primary-600 dark:text-primary-400 mb-3">
+            {bundle.title}
+          </h3>
+          <ul className="space-y-2 mb-3">
+            {bundle.items.map((item, itemIdx) => (
+              <li key={itemIdx} className="flex items-center gap-3">
+                <img
+                  src={item.imageUrl}
+                  alt={item.name}
+                  className="w-12 h-12 object-cover rounded"
+                />
+                <div className="flex-1">
+                  <p className="text-sm font-medium text-gray-900 dark:text-white">
+                    {item.name}
+                  </p>
+                </div>
+                <span className="text-sm text-primary-600 dark:text-primary-400 font-medium">
+                  ${item.price.toFixed(2)}
+                </span>
+              </li>
+            ))}
+          </ul>
+          <p className="font-bold text-primary-600 dark:text-primary-400">
+            Total: ${bundle.totalPrice.toFixed(2)}
+          </p>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default GiftBundleList;

--- a/frontend/src/components/GiftChatAssistant.tsx
+++ b/frontend/src/components/GiftChatAssistant.tsx
@@ -1,5 +1,8 @@
 import React, { useEffect, useRef, useState } from 'react';
 import api from '../api';
+import BudgetSlider from './BudgetSlider';
+import GiftBundleList from './GiftBundleList';
+import { GiftBundle } from '../types';
 
 interface Message {
   role: 'user' | 'assistant';
@@ -9,21 +12,27 @@ interface Message {
 const GiftChatAssistant: React.FC = () => {
   const [input, setInput] = useState('');
   const [messages, setMessages] = useState<Message[]>([]);
+  const [bundles, setBundles] = useState<GiftBundle[]>([]);
+  const [lastPrompt, setLastPrompt] = useState('');
+  const [budget, setBudget] = useState(100);
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
   const messagesEndRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
-  }, [messages, loading]);
+  }, [messages, loading, bundles]);
 
-  const sendPrompt = async (prompt: string): Promise<string> => {
+  const fetchBundles = async (prompt: string, currentBudget: number): Promise<GiftBundle[]> => {
+    const payload: any = { prompt };
+    if (currentBudget) payload.budget = currentBudget;
+    console.log('Sending payload:', payload);
     try {
-      const res = await api.post<{ reply: string }>('/api/giftgenius/chat', { prompt });
-      return res.data.reply;
+      const res = await api.post<{ bundles: GiftBundle[] }>('/api/giftgenius/chat', payload);
+      return res.data.bundles;
     } catch (err) {
-      console.error('Failed to fetch assistant reply', err);
-      // Fallback mocked reply
-      return `Here is a mocked response for: "${prompt}"`;
+      console.error('Failed to fetch bundles', err);
+      throw err;
     }
   };
 
@@ -34,10 +43,36 @@ const GiftChatAssistant: React.FC = () => {
     setMessages((prev) => [...prev, { role: 'user', content: prompt }]);
     setInput('');
     setLoading(true);
-    const reply = await sendPrompt(prompt);
-    setMessages((prev) => [...prev, { role: 'assistant', content: reply }]);
-    setLoading(false);
+    setError(null);
+    try {
+      const result = await fetchBundles(prompt, budget);
+      setBundles(result);
+      setLastPrompt(prompt);
+      setMessages((prev) => [...prev, { role: 'assistant', content: 'Here are some gift bundles:' }]);
+    } catch (err) {
+      setError('Failed to fetch gift bundles');
+      setMessages((prev) => [...prev, { role: 'assistant', content: 'Error fetching gift bundles.' }]);
+    } finally {
+      setLoading(false);
+    }
   };
+
+  // Re-fetch bundles when budget changes
+  useEffect(() => {
+    if (!lastPrompt) return;
+    const t = setTimeout(async () => {
+      setLoading(true);
+      try {
+        const result = await fetchBundles(lastPrompt, budget);
+        setBundles(result);
+      } catch (err) {
+        setError('Failed to fetch gift bundles');
+      } finally {
+        setLoading(false);
+      }
+    }, 500);
+    return () => clearTimeout(t);
+  }, [budget]);
 
   return (
     <div className="flex flex-col h-full">
@@ -55,11 +90,23 @@ const GiftChatAssistant: React.FC = () => {
             </div>
           </div>
         ))}
-        {loading && (
+        {loading && messages.length === 0 && (
           <div className="flex justify-start">
             <div className="max-w-[75%] rounded-lg p-3 bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-white">
               <span className="animate-pulse">...</span>
             </div>
+          </div>
+        )}
+        {bundles.length > 0 && (
+          <div className="mt-4">
+            <BudgetSlider min={25} max={500} value={budget} onChange={setBudget} />
+            {loading ? (
+              <p className="text-gray-500 dark:text-gray-400">Updating bundles...</p>
+            ) : error ? (
+              <p className="text-red-500">{error}</p>
+            ) : (
+              <GiftBundleList bundles={bundles} />
+            )}
           </div>
         )}
         <div ref={messagesEndRef} />

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -42,3 +42,16 @@ export interface Product {
   images: string[];
   reviews?: Review[];
 }
+
+export interface GiftItem {
+  name: string;
+  price: number;
+  imageUrl: string;
+  description: string;
+}
+
+export interface GiftBundle {
+  title: string;
+  items: GiftItem[];
+  totalPrice: number;
+}


### PR DESCRIPTION
## Summary
- add Flask `/api/giftgenius/chat` endpoint that returns mock gift bundles
- generate bundles from a sample product catalog and respect optional budget
- create `BudgetSlider` and `GiftBundleList` React components
- enhance `GiftChatAssistant` to show bundles and adjust them by budget
- route `/gift` to the new chat assistant

## Testing
- `python -m py_compile app.py models.py`
- `npm test -- -w=0 --watchAll=false` *(fails: Jest unable to parse axios module)*

------
https://chatgpt.com/codex/tasks/task_e_6867e7afa7f48321b1b3a0b99abcfa61