### PR TITLE
Add gift bundle generator API and React widget

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -111,10 +111,55 @@ SAMPLE_PRODUCTS: List[Dict[str, any]] = [
         "imageUrl": "https://via.placeholder.com/300?text=Cookies",
         "description": "Rich chocolate chip cookies baked to perfection.",
     },
+    {
+        "name": "Essence Mascara",
+        "price": 9.99,
+        "imageUrl": "https://via.placeholder.com/300?text=Mascara",
+        "description": "Volumizing mascara for dramatic lashes.",
+    },
+    {
+        "name": "Red Nail Polish",
+        "price": 8.99,
+        "imageUrl": "https://via.placeholder.com/300?text=Nail+Polish",
+        "description": "Quick-dry polish with a glossy finish.",
+    },
+    {
+        "name": "iPhone Charger",
+        "price": 19.99,
+        "imageUrl": "https://via.placeholder.com/300?text=Charger",
+        "description": "Fast-charging cable compatible with iPhones.",
+    },
+    {
+        "name": "Wireless Earphones",
+        "price": 49.99,
+        "imageUrl": "https://via.placeholder.com/300?text=Earphones",
+        "description": "Bluetooth earphones for music on the go.",
+    },
+    {
+        "name": "Selfie Stick",
+        "price": 12.99,
+        "imageUrl": "https://via.placeholder.com/300?text=Selfie+Stick",
+        "description": "Extendable stick for capturing selfies with ease.",
+    },
 ]
 
 # Mapping for quick lookup by product name
 PRODUCT_LOOKUP = {p["name"]: p for p in SAMPLE_PRODUCTS}
+
+# Limited subset of DummyJSON products used for gift bundle generation
+DUMMY_PRODUCTS: Dict[int, Dict[str, any]] = {
+    1: {"id": 1, "name": "Essence Mascara Lash Princess", "price": 9.99},
+    5: {"id": 5, "name": "Red Nail Polish", "price": 8.99},
+    6: {"id": 6, "name": "Calvin Klein CK One", "price": 49.99},
+    7: {"id": 7, "name": "Chanel Coco Noir Eau De", "price": 129.99},
+    8: {"id": 8, "name": "Dior J'adore", "price": 89.99},
+    104: {"id": 104, "name": "Apple iPhone Charger", "price": 19.99},
+    107: {"id": 107, "name": "Beats Flex Wireless Earphones", "price": 49.99},
+    111: {"id": 111, "name": "Selfie Stick Monopod", "price": 12.99},
+    83: {"id": 83, "name": "Blue & Black Check Shirt", "price": 29.99},
+    93: {"id": 93, "name": "Brown Leather Belt Watch", "price": 89.99},
+    163: {"id": 163, "name": "Girl Summer Dress", "price": 19.99},
+}
 
 # Predefined bundles for certain common prompts
 SPECIAL_BUNDLES: Dict[str, List[Dict[str, any]]] = {
@@ -157,63 +202,60 @@ SPECIAL_BUNDLES: Dict[str, List[Dict[str, any]]] = {
 }
 
 
-def generate_mock_bundles(prompt: str, budget: Optional[float] = None) -> List[Dict]:
-    """Generate mock gift bundles based on the prompt."""
+def generate_curated_bundles(prompt: str, budget_range: Optional[Dict[str, float]] = None) -> List[Dict]:
+    """Return curated bundles for predefined prompts filtered by budget range."""
     normalized = prompt.lower()
 
-    # Check for special cases first
     if "sister" in normalized and "birthday" in normalized:
-        bundles = SPECIAL_BUNDLES["sisters birthday"]
+        base = [
+            {"title": "Stylish Birthday Picks", "items": [DUMMY_PRODUCTS[7], DUMMY_PRODUCTS[93], DUMMY_PRODUCTS[163]]},
+            {"title": "Fragrance & Fashion", "items": [DUMMY_PRODUCTS[6], DUMMY_PRODUCTS[93], DUMMY_PRODUCTS[163]]},
+        ]
     elif "brother" in normalized and "wedding" in normalized:
-        bundles = SPECIAL_BUNDLES["brothers wedding"]
+        base = [
+            {"title": "Groom Essentials", "items": [DUMMY_PRODUCTS[93], DUMMY_PRODUCTS[83], DUMMY_PRODUCTS[8]]},
+            {"title": "Wedding Prep Kit", "items": [DUMMY_PRODUCTS[93], DUMMY_PRODUCTS[83], DUMMY_PRODUCTS[6]]},
+        ]
     else:
-        # Create random bundles if no special prompt matched
-        bundles = []
-        num_bundles = random.randint(2, 3)
-        for idx in range(num_bundles):
-            num_items = random.randint(3, 5)
-            items = random.sample(SAMPLE_PRODUCTS, k=min(num_items, len(SAMPLE_PRODUCTS)))
-            bundles.append({"title": f"Bundle {idx + 1}", "items": items})
+        # Default fallback using SAMPLE_PRODUCTS
+        base = []
+        for idx in range(2):
+            items = random.sample(SAMPLE_PRODUCTS, k=3)
+            base.append({"title": f"Bundle {idx + 1}", "items": items})
 
-    # Calculate totals and optionally trim to budget
-    processed = []
-    for bundle in bundles:
-        items = list(bundle["items"])
-        total = sum(i["price"] for i in items)
-        if budget is not None:
+    min_budget = budget_range.get("min") if budget_range else None
+    max_budget = budget_range.get("max") if budget_range else None
+
+    bundles: List[Dict] = []
+    for bundle in base:
+        total = sum(item["price"] for item in bundle["items"])
+        if (min_budget is not None and total < min_budget) or (
+            max_budget is not None and total > max_budget
+        ):
+            continue
+        bundles.append({"title": bundle["title"], "items": bundle["items"], "totalPrice": round(total, 2)})
+
+    return bundles
+
 
 def generate_mock_bundles(prompt: str, budget: Optional[float] = None) -> List[Dict]:
-    """Generate mock gift bundles."""
+    """Generate random gift bundles using SAMPLE_PRODUCTS."""
     bundles: List[Dict] = []
     num_bundles = random.randint(2, 3)
 
     for idx in range(num_bundles):
         num_items = random.randint(3, 5)
         items = random.sample(SAMPLE_PRODUCTS, k=min(num_items, len(SAMPLE_PRODUCTS)))
-
         total = sum(item["price"] for item in items)
 
         if budget is not None:
-            # Remove expensive items until under budget
             items_sorted = sorted(items, key=lambda i: i["price"])
             while total > budget and len(items_sorted) > 1:
                 removed = items_sorted.pop()
                 total -= removed["price"]
             items = items_sorted
-        processed.append({"title": bundle["title"], "items": items, "totalPrice": round(total, 2)})
 
-    if budget is not None:
-        processed = [b for b in processed if b["totalPrice"] <= budget * 1.05] or processed
-
-    return processed
-
-        bundles.append(
-            {
-                "title": f"Bundle {idx + 1}",
-                "items": items,
-                "totalPrice": round(total, 2),
-            }
-        )
+        bundles.append({"title": f"Bundle {idx + 1}", "items": items, "totalPrice": round(total, 2)})
 
     if budget is not None:
         bundles = [b for b in bundles if b["totalPrice"] <= budget * 1.05] or bundles
@@ -294,6 +336,28 @@ def get_product(product_id: int):
         return jsonify({"error": "Failed to fetch product"}), 500
 
     return jsonify(data)
+
+
+@app.route("/api/gift-bundles", methods=["POST"])
+def gift_bundles():
+    """Generate curated gift bundles based on prompt and budget range."""
+    data = request.get_json() or {}
+    prompt = (data.get("prompt") or "").strip()
+    budget_range = data.get("budgetRange") or {}
+
+    if not prompt:
+        return jsonify({"error": "Prompt required"}), 400
+
+    try:
+        br = {
+            "min": float(budget_range.get("min", 0)),
+            "max": float(budget_range.get("max", 0)),
+        }
+    except (TypeError, ValueError):
+        br = {}
+
+    bundles = generate_curated_bundles(prompt, br)
+    return jsonify({"bundles": bundles})
 
 
 @app.route("/api/giftgenius/chat", methods=["POST"])

--- a/frontend/src/components/BudgetRangeSlider.tsx
+++ b/frontend/src/components/BudgetRangeSlider.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+
+interface Props {
+  min: number;
+  max: number;
+  values: [number, number];
+  onChange: (vals: [number, number]) => void;
+}
+
+const BudgetRangeSlider: React.FC<Props> = ({ min, max, values, onChange }) => {
+  const [minVal, maxVal] = values;
+
+  const handleMin = (val: number) => {
+    const newMin = Math.min(val, maxVal);
+    onChange([newMin, maxVal]);
+  };
+
+  const handleMax = (val: number) => {
+    const newMax = Math.max(val, minVal);
+    onChange([minVal, newMax]);
+  };
+
+  return (
+    <div className="mb-4">
+      <label className="block mb-2 font-medium text-gray-900 dark:text-white">
+        Budget: ${minVal} - ${maxVal}
+      </label>
+      <div className="flex items-center space-x-2">
+        <input
+          type="range"
+          min={min}
+          max={max}
+          step={25}
+          value={minVal}
+          onChange={(e) => handleMin(Number(e.target.value))}
+          className="w-full h-2 bg-gray-200 dark:bg-gray-700 rounded-lg appearance-none cursor-pointer accent-primary-600"
+        />
+        <input
+          type="range"
+          min={min}
+          max={max}
+          step={25}
+          value={maxVal}
+          onChange={(e) => handleMax(Number(e.target.value))}
+          className="w-full h-2 bg-gray-200 dark:bg-gray-700 rounded-lg appearance-none cursor-pointer accent-primary-600"
+        />
+      </div>
+      <div className="flex justify-between text-sm text-gray-500 dark:text-gray-400 mt-1">
+        <span>${min}</span>
+        <span>${max}</span>
+      </div>
+    </div>
+  );
+};
+
+export default BudgetRangeSlider;

--- a/frontend/src/components/GiftBundleGenerator.tsx
+++ b/frontend/src/components/GiftBundleGenerator.tsx
@@ -1,0 +1,96 @@
+import React, { useState } from 'react';
+import api from '../api';
+import { GiftBundle } from '../types';
+import BudgetRangeSlider from './BudgetRangeSlider';
+
+const prompts = [
+  { label: "Sister's Birthday", value: "sister's birthday" },
+  { label: "Brother's Wedding", value: "brother's wedding" },
+];
+
+const GiftBundleGenerator: React.FC = () => {
+  const [prompt, setPrompt] = useState(prompts[0].value);
+  const [range, setRange] = useState<[number, number]>([50, 150]);
+  const [bundles, setBundles] = useState<GiftBundle[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const fetchBundles = async () => {
+    setLoading(true);
+    try {
+      const res = await api.post<{ bundles: GiftBundle[] }>('/api/gift-bundles', {
+        prompt,
+        budgetRange: { min: range[0], max: range[1] },
+      });
+      setBundles(res.data.bundles);
+    } catch (err) {
+      console.error('Failed to fetch bundles', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleAddAll = (bundle: GiftBundle) => {
+    console.log('Add All to Cart', bundle);
+  };
+
+  return (
+    <div className="max-w-xl mx-auto p-4 space-y-4">
+      <div>
+        <label className="block mb-1 font-medium text-gray-900 dark:text-white">
+          Occasion
+        </label>
+        <select
+          value={prompt}
+          onChange={(e) => setPrompt(e.target.value)}
+          className="border border-gray-300 dark:border-gray-600 rounded-md p-2 w-full bg-white dark:bg-gray-800"
+        >
+          {prompts.map((p) => (
+            <option key={p.value} value={p.value}>
+              {p.label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <BudgetRangeSlider min={25} max={500} values={range} onChange={setRange} />
+
+      <button
+        onClick={fetchBundles}
+        disabled={loading}
+        className="bg-primary-500 hover:bg-primary-600 text-white px-4 py-2 rounded-md font-medium transition-all disabled:opacity-50"
+      >
+        {loading ? 'Generating...' : 'Generate Bundles'}
+      </button>
+
+      <div className="space-y-4 max-h-96 overflow-y-auto">
+        {bundles.map((bundle, idx) => (
+          <div
+            key={idx}
+            className="border border-gray-200 dark:border-gray-700 rounded-lg p-4 shadow hover:shadow-md transition-all"
+          >
+            <h3 className="text-lg font-semibold text-primary-600 dark:text-primary-400 mb-2">
+              {bundle.title}
+            </h3>
+            <ul className="space-y-1 mb-3">
+              {bundle.items.map((item, i) => (
+                <li key={i} className="flex justify-between text-sm">
+                  <span>{item.name}</span>
+                  <span className="font-medium">${item.price.toFixed(2)}</span>
+                </li>
+              ))}
+            </ul>
+            <p className="font-bold mb-2">Total: ${bundle.totalPrice.toFixed(2)}</p>
+            <button
+              onClick={() => handleAddAll(bundle)}
+              className="bg-accent-400 hover:bg-accent-500 text-gray-900 px-3 py-1 rounded-md"
+            >
+              Add All to Cart
+            </button>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default GiftBundleGenerator;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -44,6 +44,7 @@ export interface Product {
 }
 
 export interface GiftItem {
+  id?: number;
   name: string;
   price: number;
   imageUrl: string;


### PR DESCRIPTION
## Summary
- implement a curated gift bundle generator route in Flask
- add dummyjson product samples for bundles
- create BudgetRangeSlider and GiftBundleGenerator React components
- extend GiftItem type with optional id
- add more sample products for beauty and phone accessories

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend test -- --watchAll=false` *(fails: Jest encountered unexpected token)*
- `python -m py_compile backend/app.py`


------
https://chatgpt.com/codex/tasks/task_e_6869114be26c8321953bed070cc55c92