### PR TITLE
Integrate Supabase auth in React

### DIFF
--- a/frontend/src/components/LoginForm.tsx
+++ b/frontend/src/components/LoginForm.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import api from '../api';
+import { useAuth } from '../context/AuthContext';
 import { useNavigate } from 'react-router-dom';
 import { toast } from 'react-toastify';
 
@@ -8,18 +8,18 @@ const LoginForm: React.FC = () => {
   const [password, setPassword] = useState('');
   const [loading, setLoading] = useState(false);
   const navigate = useNavigate();
+  const { loginUser } = useAuth();
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (loading) return;
     setLoading(true);
     try {
-      const res = await api.post('/api/login', { email, password });
-      localStorage.setItem('auth_token', res.data.token);
+      await loginUser(email, password);
       toast.success('Logged in');
       navigate('/dashboard');
     } catch (err: any) {
-      toast.error(err.response?.data?.error || 'Login failed');
+      toast.error(err.message || 'Login failed');
     } finally {
       setLoading(false);
     }

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -1,8 +1,11 @@
 import React, { useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
 
 const Navbar: React.FC = () => {
   const [isOpen, setIsOpen] = useState(false);
+  const { isAuthenticated, logoutUser } = useAuth();
+  const navigate = useNavigate();
 
   return (
     <nav className="bg-primary-600 text-white shadow-lg">
@@ -37,12 +40,24 @@ const Navbar: React.FC = () => {
               >
                 Cart
               </Link>
-              <Link
-                to="/login"
-                className="px-3 py-2 rounded-md text-sm font-medium hover:bg-primary-500 hover:text-accent-300 transition-all"
-              >
-                Login
-              </Link>
+              {isAuthenticated ? (
+                <button
+                  onClick={async () => {
+                    await logoutUser();
+                    navigate('/login');
+                  }}
+                  className="px-3 py-2 rounded-md text-sm font-medium hover:bg-primary-500 hover:text-accent-300 transition-all"
+                >
+                  Logout
+                </button>
+              ) : (
+                <Link
+                  to="/login"
+                  className="px-3 py-2 rounded-md text-sm font-medium hover:bg-primary-500 hover:text-accent-300 transition-all"
+                >
+                  Login
+                </Link>
+              )}
               <Link
                 to="/profile"
                 className="px-3 py-2 rounded-md text-sm font-medium hover:bg-primary-500 hover:text-accent-300 transition-all"
@@ -98,13 +113,26 @@ const Navbar: React.FC = () => {
           >
             Cart
           </Link>
-          <Link
-            to="/login"
-            className="block px-3 py-2 rounded-md text-base font-medium hover:bg-primary-500 hover:text-accent-300 transition-all"
-            onClick={() => setIsOpen(false)}
-          >
-            Login
-          </Link>
+          {isAuthenticated ? (
+            <button
+              onClick={async () => {
+                setIsOpen(false);
+                await logoutUser();
+                navigate('/login');
+              }}
+              className="block w-full text-left px-3 py-2 rounded-md text-base font-medium hover:bg-primary-500 hover:text-accent-300 transition-all"
+            >
+              Logout
+            </button>
+          ) : (
+            <Link
+              to="/login"
+              className="block px-3 py-2 rounded-md text-base font-medium hover:bg-primary-500 hover:text-accent-300 transition-all"
+              onClick={() => setIsOpen(false)}
+            >
+              Login
+            </Link>
+          )}
           <Link
             to="/profile"
             className="block px-3 py-2 rounded-md text-base font-medium hover:bg-primary-500 hover:text-accent-300 transition-all"

--- a/frontend/src/components/RegisterForm.tsx
+++ b/frontend/src/components/RegisterForm.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import api from '../api';
+import { supabase } from '../supabaseClient';
 import { toast } from 'react-toastify';
 
 const RegisterForm: React.FC = () => {
@@ -12,10 +12,11 @@ const RegisterForm: React.FC = () => {
     if (loading) return;
     setLoading(true);
     try {
-      await api.post('/api/register', { email, password });
+      const { error } = await supabase.auth.signUp({ email, password });
+      if (error) throw error;
       toast.success('Account created');
     } catch (err: any) {
-      toast.error(err.response?.data?.error || 'Registration failed');
+      toast.error(err.message || 'Registration failed');
     } finally {
       setLoading(false);
     }

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -1,0 +1,60 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import { Session, User } from '@supabase/supabase-js';
+import { supabase } from '../supabaseClient';
+
+interface AuthContextType {
+  session: Session | null;
+  user: User | null;
+  loginUser: (email: string, password: string) => Promise<void>;
+  logoutUser: () => Promise<void>;
+  isAuthenticated: boolean;
+}
+
+const AuthContext = createContext<AuthContextType | undefined>(undefined);
+
+export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [session, setSession] = useState<Session | null>(null);
+  const [user, setUser] = useState<User | null>(null);
+
+  useEffect(() => {
+    const init = async () => {
+      const { data } = await supabase.auth.getSession();
+      setSession(data.session);
+      setUser(data.session?.user ?? null);
+    };
+
+    init();
+
+    const { data: listener } = supabase.auth.onAuthStateChange((_event, session) => {
+      setSession(session);
+      setUser(session?.user ?? null);
+    });
+
+    return () => {
+      listener.subscription.unsubscribe();
+    };
+  }, []);
+
+  const loginUser = async (email: string, password: string) => {
+    const { error } = await supabase.auth.signInWithPassword({ email, password });
+    if (error) throw error;
+  };
+
+  const logoutUser = async () => {
+    await supabase.auth.signOut();
+  };
+
+  return (
+    <AuthContext.Provider value={{ session, user, loginUser, logoutUser, isAuthenticated: !!session }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export const useAuth = (): AuthContextType => {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+  return context;
+};

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -3,13 +3,16 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
+import { AuthProvider } from './context/AuthContext';
 
 const root = ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement
 );
 root.render(
   <React.StrictMode>
-    <App />
+    <AuthProvider>
+      <App />
+    </AuthProvider>
   </React.StrictMode>
 );
 

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { supabase } from '../supabaseClient';
+import { useAuth } from '../context/AuthContext';
 
 interface Profile {
   id: string;
@@ -18,15 +19,14 @@ const ProfilePage: React.FC = () => {
   const [autoOrder, setAutoOrder] = useState<boolean>(false);
   const [loading, setLoading] = useState<boolean>(true);
   const navigate = useNavigate();
+  const { session, user } = useAuth();
 
   useEffect(() => {
     const loadProfile = async () => {
-      const { data: { session } } = await supabase.auth.getSession();
-      if (!session) {
+      if (!session || !user) {
         navigate('/login');
         return;
       }
-      const user = session.user;
       try {
         // Fetch user profile info
         const { data, error } = await supabase
@@ -61,7 +61,7 @@ const ProfilePage: React.FC = () => {
     };
 
     loadProfile();
-  }, [navigate]);
+  }, [navigate, session, user]);
 
   const toggleAutoOrder = async () => {
     if (!profile) return;


### PR DESCRIPTION
## Summary
- add `AuthContext` and provider for Supabase session management
- switch `LoginForm` and `RegisterForm` to Supabase auth API
- show logout button in `Navbar`
- wrap the app with `AuthProvider`
- protect `ProfilePage` via session from context

## Testing
- `npm test --silent -- --watchAll=false` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_686a1f7a3e38832198f19d0089b08e94