### PR TITLE
Enable product search in pantry setup

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -210,6 +210,24 @@ def get_products():
     return jsonify(data.get("products", []))
 
 
+@app.route("/api/products/search", methods=["GET"])
+def search_products():
+    """Search products by query string using DummyJSON."""
+    query = (request.args.get("q") or "").strip()
+    if not query:
+        return jsonify([])
+    try:
+        resp = requests.get(
+            "https://dummyjson.com/products/search", params={"q": query}
+        )
+        resp.raise_for_status()
+        data = resp.json()
+    except requests.RequestException:
+        return jsonify({"error": "Failed to search products"}), 500
+
+    return jsonify(data.get("products", []))
+
+
 @app.route("/api/products/<int:product_id>", methods=["GET"])
 def get_product(product_id: int):
     """Fetch a single product by id from DummyJSON."""


### PR DESCRIPTION
## Summary
- add `/api/products/search` endpoint on the Flask backend
- enhance `PantrySetup` page with product search dropdown
- auto-fill item name and category when a product is selected
- log API calls and form payloads in console

## Testing
- `pytest -q` *(no tests found)*
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a24ea20cc8321bc16346817495e47