### PR TITLE
Switch GiftGenius to prompt input

### DIFF
--- a/frontend/src/components/GiftBundleGenerator.tsx
+++ b/frontend/src/components/GiftBundleGenerator.tsx
@@ -3,13 +3,8 @@ import api from '../api';
 import { GiftBundle } from '../types';
 import BudgetRangeSlider from './BudgetRangeSlider';
 
-const prompts = [
-  { label: "Sister Birthday", value: "sister birthday" },
-  { label: "Brother Wedding", value: "brother wedding" },
-];
-
 const GiftBundleGenerator: React.FC = () => {
-  const [prompt, setPrompt] = useState(prompts[0].value);
+  const [prompt, setPrompt] = useState('');
   const [range, setRange] = useState<[number, number]>([50, 150]);
   const [bundles, setBundles] = useState<GiftBundle[]>([]);
   const [loading, setLoading] = useState(false);
@@ -17,6 +12,7 @@ const GiftBundleGenerator: React.FC = () => {
   const fetchBundles = async () => {
     setLoading(true);
     try {
+      console.log('Fetching gift bundles for prompt:', prompt);
       const res = await api.post<{ bundles: GiftBundle[] }>('/api/gift-bundles', {
         prompt,
         budgetRange: { min: range[0], max: range[1] },
@@ -35,32 +31,36 @@ const GiftBundleGenerator: React.FC = () => {
 
   return (
     <div className="max-w-xl mx-auto p-4 space-y-4">
-      <div>
-        <label className="block mb-1 font-medium text-gray-900 dark:text-white">
-          Occasion
-        </label>
-        <select
-          value={prompt}
-          onChange={(e) => setPrompt(e.target.value)}
-          className="border border-gray-300 dark:border-gray-600 rounded-md p-2 w-full bg-white dark:bg-gray-800"
-        >
-          {prompts.map((p) => (
-            <option key={p.value} value={p.value}>
-              {p.label}
-            </option>
-          ))}
-        </select>
-      </div>
-
-      <BudgetRangeSlider min={25} max={500} values={range} onChange={setRange} />
-
-      <button
-        onClick={fetchBundles}
-        disabled={loading}
-        className="bg-primary-500 hover:bg-primary-600 text-white px-4 py-2 rounded-md font-medium transition-all disabled:opacity-50"
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          fetchBundles();
+        }}
+        className="space-y-4"
       >
-        {loading ? 'Generating...' : 'Generate Bundles'}
-      </button>
+        <div>
+          <label className="block mb-1 font-medium text-gray-900 dark:text-white">
+            Enter your gift request
+          </label>
+          <input
+            type="text"
+            value={prompt}
+            onChange={(e) => setPrompt(e.target.value)}
+            placeholder="e.g., gift for sister's birthday"
+            className="border border-gray-300 dark:border-gray-600 rounded-md p-2 w-full bg-white dark:bg-gray-800"
+          />
+        </div>
+
+        <BudgetRangeSlider min={25} max={500} values={range} onChange={setRange} />
+
+        <button
+          type="submit"
+          disabled={loading}
+          className="bg-primary-500 hover:bg-primary-600 text-white px-4 py-2 rounded-md font-medium transition-all disabled:opacity-50"
+        >
+          {loading ? 'Generating...' : 'Find Gifts'}
+        </button>
+      </form>
 
       <div className="space-y-4 max-h-96 overflow-y-auto">
         {bundles.map((bundle, idx) => (


### PR DESCRIPTION
## Summary
- swap the occasion dropdown for a free-text prompt in `GiftBundleGenerator`
- send typed prompt to `/api/gift-bundles` and log the payload
- allow pressing Enter or clicking **Find Gifts** button

## Testing
- `npm install --prefix frontend`
- `npm test --prefix frontend` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_686a2c73190483218aa23418d30c18cd