### PR TITLE
Fix product selection TypeScript error

### DIFF
--- a/frontend/src/pages/PantrySetup.tsx
+++ b/frontend/src/pages/PantrySetup.tsx
@@ -123,7 +123,7 @@ const PantrySetup: React.FC = () => {
   }, [search]);
 
   const handleSelectProduct = (product: Product) => {
-    setName(product.title || product.name);
+    setName(product.title || product.name || '');
     setCategory(product.category);
     setShowResults(false);
     setResults([]);


### PR DESCRIPTION
## Summary
- fix type mismatch in `handleSelectProduct`

## Testing
- `npm test --silent` *(fails: SyntaxError: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_686a2b4f3240832195eb8a470c007155