### PR TITLE
Switch GiftGenius to prompt input

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20,6 +20,7 @@
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
         "axios": "^1.10.0",
+        "rc-slider": "^11.1.8",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-icons": "^5.5.0",
@@ -5964,6 +5965,12 @@
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
       "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
+      "license": "MIT"
+    },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
       "license": "MIT"
     },
     "node_modules/clean-css": {
@@ -14224,6 +14231,44 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/rc-slider": {
+      "version": "11.1.8",
+      "resolved": "https://registry.npmjs.org/rc-slider/-/rc-slider-11.1.8.tgz",
+      "integrity": "sha512-2gg/72YFSpKP+Ja5AjC5DPL1YnV8DEITDQrcc1eASrUYjl0esptaBVJBh5nLTXCCp15eD8EuGjwezVGSHhs9tQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.10.1",
+        "classnames": "^2.2.5",
+        "rc-util": "^5.36.0"
+      },
+      "engines": {
+        "node": ">=8.x"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/rc-util": {
+      "version": "5.44.4",
+      "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-5.44.4.tgz",
+      "integrity": "sha512-resueRJzmHG9Q6rI/DfK6Kdv9/Lfls05vzMs1Sk3M2P+3cJa+MakaZyWY8IPfehVuhPJFKrIY1IK4GqbiaiY5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "react-is": "^18.2.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/rc-util/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT"
     },
     "node_modules/react": {
       "version": "19.1.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "axios": "^1.10.0",
+    "rc-slider": "^11.1.8",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-icons": "^5.5.0",

--- a/frontend/src/components/BudgetRangeSlider.tsx
+++ b/frontend/src/components/BudgetRangeSlider.tsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import Slider, { Range } from 'rc-slider';
+import 'rc-slider/assets/index.css';
 
 interface Props {
   min: number;
@@ -10,14 +12,9 @@ interface Props {
 const BudgetRangeSlider: React.FC<Props> = ({ min, max, values, onChange }) => {
   const [minVal, maxVal] = values;
 
-  const handleMin = (val: number) => {
-    const newMin = Math.min(val, maxVal);
-    onChange([newMin, maxVal]);
-  };
-
-  const handleMax = (val: number) => {
-    const newMax = Math.max(val, minVal);
-    onChange([minVal, newMax]);
+  const handleChange = (vals: number[]) => {
+    const [newMin, newMax] = vals;
+    onChange([newMin, newMax]);
   };
 
   return (
@@ -25,26 +22,20 @@ const BudgetRangeSlider: React.FC<Props> = ({ min, max, values, onChange }) => {
       <label className="block mb-2 font-medium text-gray-900 dark:text-white">
         Budget: ${minVal} - ${maxVal}
       </label>
-      <div className="flex items-center space-x-2">
-        <input
-          type="range"
-          min={min}
-          max={max}
-          step={25}
-          value={minVal}
-          onChange={(e) => handleMin(Number(e.target.value))}
-          className="w-full h-2 bg-gray-200 dark:bg-gray-700 rounded-lg appearance-none cursor-pointer accent-primary-600"
-        />
-        <input
-          type="range"
-          min={min}
-          max={max}
-          step={25}
-          value={maxVal}
-          onChange={(e) => handleMax(Number(e.target.value))}
-          className="w-full h-2 bg-gray-200 dark:bg-gray-700 rounded-lg appearance-none cursor-pointer accent-primary-600"
-        />
-      </div>
+      <Range
+        min={min}
+        max={max}
+        step={25}
+        allowCross={false}
+        value={[minVal, maxVal]}
+        onChange={handleChange}
+        trackStyle={[{ backgroundColor: '#3b82f6' }]}
+        handleStyle={[
+          { borderColor: '#3b82f6' },
+          { borderColor: '#3b82f6' },
+        ]}
+        railStyle={{ backgroundColor: '#e5e7eb' }}
+      />
       <div className="flex justify-between text-sm text-gray-500 dark:text-gray-400 mt-1">
         <span>${min}</span>
         <span>${max}</span>

--- a/frontend/src/components/GiftBundleGenerator.tsx
+++ b/frontend/src/components/GiftBundleGenerator.tsx
@@ -3,13 +3,8 @@ import api from '../api';
 import { GiftBundle } from '../types';
 import BudgetRangeSlider from './BudgetRangeSlider';
 
-const prompts = [
-  { label: "Sister Birthday", value: "sister birthday" },
-  { label: "Brother Wedding", value: "brother wedding" },
-];
-
 const GiftBundleGenerator: React.FC = () => {
-  const [prompt, setPrompt] = useState(prompts[0].value);
+  const [prompt, setPrompt] = useState('');
   const [range, setRange] = useState<[number, number]>([50, 150]);
   const [bundles, setBundles] = useState<GiftBundle[]>([]);
   const [loading, setLoading] = useState(false);
@@ -17,6 +12,7 @@ const GiftBundleGenerator: React.FC = () => {
   const fetchBundles = async () => {
     setLoading(true);
     try {
+      console.log('Fetching gift bundles for prompt:', prompt);
       const res = await api.post<{ bundles: GiftBundle[] }>('/api/gift-bundles', {
         prompt,
         budgetRange: { min: range[0], max: range[1] },
@@ -35,32 +31,36 @@ const GiftBundleGenerator: React.FC = () => {
 
   return (
     <div className="max-w-xl mx-auto p-4 space-y-4">
-      <div>
-        <label className="block mb-1 font-medium text-gray-900 dark:text-white">
-          Occasion
-        </label>
-        <select
-          value={prompt}
-          onChange={(e) => setPrompt(e.target.value)}
-          className="border border-gray-300 dark:border-gray-600 rounded-md p-2 w-full bg-white dark:bg-gray-800"
-        >
-          {prompts.map((p) => (
-            <option key={p.value} value={p.value}>
-              {p.label}
-            </option>
-          ))}
-        </select>
-      </div>
-
-      <BudgetRangeSlider min={25} max={500} values={range} onChange={setRange} />
-
-      <button
-        onClick={fetchBundles}
-        disabled={loading}
-        className="bg-primary-500 hover:bg-primary-600 text-white px-4 py-2 rounded-md font-medium transition-all disabled:opacity-50"
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          fetchBundles();
+        }}
+        className="space-y-4"
       >
-        {loading ? 'Generating...' : 'Generate Bundles'}
-      </button>
+        <div>
+          <label className="block mb-1 font-medium text-gray-900 dark:text-white">
+            Enter your gift request
+          </label>
+          <input
+            type="text"
+            value={prompt}
+            onChange={(e) => setPrompt(e.target.value)}
+            placeholder="e.g., gift for sister's birthday"
+            className="border border-gray-300 dark:border-gray-600 rounded-md p-2 w-full bg-white dark:bg-gray-800"
+          />
+        </div>
+
+        <BudgetRangeSlider min={25} max={500} values={range} onChange={setRange} />
+
+        <button
+          type="submit"
+          disabled={loading}
+          className="bg-primary-500 hover:bg-primary-600 text-white px-4 py-2 rounded-md font-medium transition-all disabled:opacity-50"
+        >
+          {loading ? 'Generating...' : 'Find Gifts'}
+        </button>
+      </form>
 
       <div className="space-y-4 max-h-96 overflow-y-auto">
         {bundles.map((bundle, idx) => (


### PR DESCRIPTION
## Summary
- swap the occasion dropdown for a free-text prompt in `GiftBundleGenerator`
- use `rc-slider` Range component for a single budget slider
- send typed prompt to `/api/gift-bundles` and log the payload
- allow pressing Enter or clicking **Find Gifts** button

## Testing
- `npm test --prefix frontend --silent` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_686a2c73190483218aa23418d30c18cd