### PR TITLE
Switch gift generator to single budget slider

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -247,15 +247,19 @@ def gift_bundles():
     data = request.get_json() or {}
     prompt = (data.get("prompt") or "").strip()
     budget_range = data.get("budgetRange") or {}
+    budget = data.get("budget")
 
     if not prompt:
         return jsonify({"error": "Prompt required"}), 400
 
     try:
-        br = {
-            "min": float(budget_range.get("min", 0)),
-            "max": float(budget_range.get("max", 0)),
-        }
+        if budget is not None:
+            br = {"min": 0, "max": float(budget)}
+        else:
+            br = {
+                "min": float(budget_range.get("min", 0)),
+                "max": float(budget_range.get("max", 0)),
+            }
     except (TypeError, ValueError):
         br = {}
 


### PR DESCRIPTION
## Summary
- use `BudgetSlider` in `GiftBundleGenerator`
- reload bundles when budget changes
- allow `/api/gift-bundles` to accept a single `budget` value

## Testing
- `npm test --silent --prefix frontend` *(fails: react-scripts not found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686a3c154790832180bd066b774a2dcc