### PR TITLE
Switch gift generator to single budget slider

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -126,12 +126,30 @@ def generate_curated_bundles(prompt: str, budget_range: Optional[Dict[str, float
 
     bundles: List[Dict] = []
     for bundle in base:
-        total = sum(item["price"] for item in bundle["items"])
-        if (min_budget is not None and total < min_budget) or (
-            max_budget is not None and total > max_budget
-        ):
+        items = list(bundle["items"])
+        total = sum(item["price"] for item in items)
+
+        if max_budget is not None:
+            # Remove most expensive items until under budget, leaving at least one
+            items.sort(key=lambda x: x["price"])
+            while len(items) > 1 and total > max_budget:
+                removed = items.pop()  # remove highest price
+                total -= removed["price"]
+
+            # Try adding cheaper extras if budget allows
+            if total < max_budget:
+                extras = [p for p in DUMMY_PRODUCTS.values() if p not in items]
+                extras.sort(key=lambda x: x["price"])
+                for prod in extras:
+                    if total + prod["price"] <= max_budget:
+                        items.append(prod)
+                        total += prod["price"]
+
+        if min_budget is not None and total < min_budget:
             continue
-        bundles.append({"title": bundle["title"], "items": bundle["items"], "totalPrice": round(total, 2)})
+
+        bundles.append({"title": bundle["title"], "items": items, "totalPrice": round(total, 2)})
+
     if not bundles:
         # If nothing met the budget criteria, return all bundles unfiltered
         bundles = [
@@ -142,7 +160,6 @@ def generate_curated_bundles(prompt: str, budget_range: Optional[Dict[str, float
             }
             for b in base
         ]
-
 
     return bundles
 
@@ -247,15 +264,19 @@ def gift_bundles():
     data = request.get_json() or {}
     prompt = (data.get("prompt") or "").strip()
     budget_range = data.get("budgetRange") or {}
+    budget = data.get("budget")
 
     if not prompt:
         return jsonify({"error": "Prompt required"}), 400
 
     try:
-        br = {
-            "min": float(budget_range.get("min", 0)),
-            "max": float(budget_range.get("max", 0)),
-        }
+        if budget is not None:
+            br = {"min": 0, "max": float(budget)}
+        else:
+            br = {
+                "min": float(budget_range.get("min", 0)),
+                "max": float(budget_range.get("max", 0)),
+            }
     except (TypeError, ValueError):
         br = {}
 


### PR DESCRIPTION
## Summary
- use `BudgetSlider` in `GiftBundleGenerator`
- reload bundles when budget changes
- allow `/api/gift-bundles` to accept a single `budget` value
- refine bundle generation to add or remove items based on budget

## Testing
- `npm test --silent --prefix frontend` *(fails: react-scripts not found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686a3c154790832180bd066b774a2dcc