### PR TITLE
Fix custom bundle item names

### DIFF
--- a/frontend/src/pages/GiftBundlePage.tsx
+++ b/frontend/src/pages/GiftBundlePage.tsx
@@ -17,7 +17,7 @@ const GiftBundlePage: React.FC = () => {
     title: b.title,
     items: b.items.map((item) => ({
       id: item.id,
-      name: item.title,
+      name: (item as any).title ?? (item as any).name ?? '',
       price: item.price,
       imageUrl: (item as any).image ?? (item as any).thumbnail,
       description: item.description,


### PR DESCRIPTION
## Summary
- show item title in gift bundle customizer

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot read properties of null)*

------
https://chatgpt.com/codex/tasks/task_e_686a5e5f14b083219f7887286c65ed46