### PR TITLE
Restrict search results to prefix matches

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -229,20 +229,25 @@ def get_products():
 
 @app.route("/api/products/search", methods=["GET"])
 def search_products():
-    """Search products by query string using DummyJSON."""
-    query = (request.args.get("q") or "").strip()
+    """Search products by prefix against the main product list."""
+    query = (request.args.get("q") or "").strip().lower()
     if not query:
         return jsonify([])
+
     try:
         resp = requests.get(
-            "https://dummyjson.com/products/search", params={"q": query}
+            "https://dummyjson.com/products", params={"limit": 100, "skip": 0}
         )
         resp.raise_for_status()
         data = resp.json()
     except requests.RequestException:
-        return jsonify({"error": "Failed to search products"}), 500
+        return jsonify({"error": "Failed to fetch products"}), 500
 
-    return jsonify(data.get("products", []))
+    products = data.get("products", [])
+    filtered = [
+        p for p in products if p.get("title", "").lower().startswith(query)
+    ]
+    return jsonify(filtered)
 
 
 @app.route("/api/products/<int:product_id>", methods=["GET"])

--- a/frontend/src/pages/PantrySetup.tsx
+++ b/frontend/src/pages/PantrySetup.tsx
@@ -114,7 +114,7 @@ const PantrySetup: React.FC = () => {
       } catch (err) {
         console.error('Search failed, falling back to mock', err);
         const filtered = mockProducts.filter((p) =>
-          p.title.toLowerCase().includes(search.toLowerCase())
+          p.title.toLowerCase().startsWith(search.toLowerCase())
         );
         setResults(filtered as unknown as Product[]);
       }

--- a/frontend/src/pages/ProductSearch.tsx
+++ b/frontend/src/pages/ProductSearch.tsx
@@ -54,7 +54,7 @@ const ProductSearch: React.FC = () => {
   };
 
   const filtered = products.filter((p) => {
-    const matchesQuery = query ? p.title.toLowerCase().includes(query) : true;
+    const matchesQuery = query ? p.title.toLowerCase().startsWith(query) : true;
     const matchesCategory = category ? p.category.toLowerCase() === category : true;
     return matchesQuery && matchesCategory;
   });


### PR DESCRIPTION
## Summary
- restrict product search API to our list of 100 products and filter by prefix
- update SmartPantry product search pages to use prefix matching only

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found or jest issue)*

------
https://chatgpt.com/codex/tasks/task_e_686b6095bb448321aed7ec316a2eda16