### PR TITLE
Add consumption rate and reorder buffer

### DIFF
--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -88,13 +88,14 @@ const Profile: React.FC = () => {
             <label htmlFor="buffer" className="block mb-2 font-medium text-gray-900 dark:text-white">
               Reorder Buffer
               <span className="text-sm text-gray-500 dark:text-gray-400 block">
-                Days before running out to reorder
+                Reorder when this percent remains
               </span>
             </label>
             <input
               id="buffer"
               type="number"
               min={1}
+              max={100}
               className="bg-gray-50 border border-gray-300 dark:border-gray-600 text-gray-900 dark:text-white dark:bg-gray-700 rounded-lg focus:ring-primary-500 focus:border-primary-500 block w-24 p-2.5"
               value={reorderBuffer}
               onChange={(e) => setReorderBuffer(parseInt(e.target.value))}


### PR DESCRIPTION
## Summary
- simplify SmartPantry item fields to just rate, days and reorder buffer
- tweak profile page to use percent-based buffer

## Testing
- `npx tsc --noEmit`
- `CI=true npm test --silent` *(fails: Jest unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_686b6a8c3a1083218beab4ec9f916b67