### PR TITLE
Support adding bundles as single cart items

### DIFF
--- a/frontend/src/context/CartContext.tsx
+++ b/frontend/src/context/CartContext.tsx
@@ -1,9 +1,12 @@
 import React, { createContext, useContext, useState } from 'react';
-import { Product } from '../types';
+import { Product, GiftItem } from '../types';
 import { toast } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
 
-export type ProductWithQty = Product & { quantity: number };
+export type ProductWithQty = Product & {
+  quantity: number;
+  bundleItems?: GiftItem[];
+};
 
 interface CartContextProps {
   cartItems: ProductWithQty[];

--- a/frontend/src/pages/CartPage.tsx
+++ b/frontend/src/pages/CartPage.tsx
@@ -103,8 +103,14 @@ const CartPage: React.FC = () => {
               key={item.id}
               className="flex flex-col sm:flex-row items-center border border-gray-200 dark:border-gray-700 p-4 rounded-lg bg-white dark:bg-gray-800 shadow-sm hover:shadow-md transition-all"
             >
-              <Link 
-                to={`/products/${item.id}`}
+              <Link
+                to={item.isBundle ? "/bundle" : `/products/${item.id}`}
+                state={item.isBundle ? { bundle: {
+                  title: item.title,
+                  items: item.bundleItems,
+                  totalPrice: item.price,
+                  discountPercent: item.discountPercentage,
+                } } : undefined}
                 className="w-24 h-24 flex-shrink-0 mb-4 sm:mb-0 sm:mr-6"
               >
                 <img
@@ -115,8 +121,14 @@ const CartPage: React.FC = () => {
               </Link>
               
               <div className="flex-1 w-full sm:w-auto text-center sm:text-left mb-4 sm:mb-0">
-                <Link 
-                  to={`/products/${item.id}`}
+                <Link
+                  to={item.isBundle ? "/bundle" : `/products/${item.id}`}
+                  state={item.isBundle ? { bundle: {
+                    title: item.title,
+                    items: item.bundleItems,
+                    totalPrice: item.price,
+                    discountPercent: item.discountPercentage,
+                  } } : undefined}
                   className="font-semibold text-gray-900 dark:text-white hover:text-primary-500 dark:hover:text-primary-400 transition-colors"
                 >
                   {item.title}
@@ -143,6 +155,30 @@ const CartPage: React.FC = () => {
                     </>
                   );
                 })()}
+                {item.bundleItems && (
+                  <ul className="text-sm text-gray-500 dark:text-gray-400 mt-2">
+                    {item.bundleItems.map((bi) => (
+                      <li key={bi.name} className="flex justify-between">
+                        <span>{bi.name}</span>
+                        <span>${bi.price.toFixed(2)}</span>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+                {item.isBundle && (
+                  <Link
+                    to="/bundle"
+                    state={{ bundle: {
+                      title: item.title,
+                      items: item.bundleItems,
+                      totalPrice: item.price,
+                      discountPercent: item.discountPercentage,
+                    }}}
+                    className="text-sm text-primary-600 dark:text-primary-400 underline mt-2 inline-block"
+                  >
+                    Customize Bundle
+                  </Link>
+                )}
               </div>
               
               <div className="flex items-center gap-4">

--- a/frontend/src/pages/GiftBundlePage.tsx
+++ b/frontend/src/pages/GiftBundlePage.tsx
@@ -50,19 +50,24 @@ const GiftBundlePage: React.FC = () => {
   const handleAddAllToCart = () => {
     if (!currentBundle) return;
 
-    currentBundle.items.forEach((item) => {
-      const prod: ProductWithQty = {
-        id: item.id!,
-        title: item.name,
-        price: item.price,
-        description: item.description,
-        category: "bundle",
-        thumbnail: item.imageUrl,
-        images: [item.imageUrl],
-        quantity: 1,
-      } as any;
-      addToCart(prod);
-    });
+    const subtotal = currentBundle.items.reduce((sum, i) => sum + i.price, 0);
+    const discountPercent = currentBundle.discountPercent ??
+      Math.round((1 - currentBundle.totalPrice / subtotal) * 100);
+
+    const prod: ProductWithQty = {
+      id: Date.now(),
+      title: currentBundle.title,
+      description: `Bundle of ${currentBundle.items.length} items`,
+      price: currentBundle.totalPrice,
+      discountPercentage: discountPercent,
+      category: "bundle",
+      thumbnail: currentBundle.items[0]?.imageUrl || "",
+      images: currentBundle.items.map((i) => i.imageUrl),
+      quantity: 1,
+      bundleItems: currentBundle.items,
+      isBundle: true,
+    } as any;
+    addToCart(prod);
     toast.success(`Added "${currentBundle.title}" bundle to cart!`);
   };
 

--- a/frontend/src/pages/GiftGenius.tsx
+++ b/frontend/src/pages/GiftGenius.tsx
@@ -42,19 +42,30 @@ const GiftGenius: React.FC = () => {
   };
 
   const handleAddAll = (bundle: GiftBundle) => {
-    bundle.items.forEach((item) => {
-      const prod: ProductWithQty = {
-        id: item.id,
-        title: item.title,
-        price: item.price,
-        description: item.description,
-        category: item.category,
-        thumbnail: item.image,
-        images: [item.image],
-        quantity: 1,
-      } as any;
-      addToCart(prod);
-    });
+    const subtotal = bundle.items.reduce((sum, i) => sum + i.price, 0);
+    const discountPercent = bundle.discountPercent ??
+      Math.round((1 - bundle.totalPrice / subtotal) * 100);
+
+    const prod: ProductWithQty = {
+      id: Date.now(),
+      title: bundle.title,
+      description: `Bundle of ${bundle.items.length} items`,
+      price: bundle.totalPrice,
+      discountPercentage: discountPercent,
+      category: "bundle",
+      thumbnail: bundle.items[0]?.image ?? "",
+      images: bundle.items.map((i) => i.image),
+      quantity: 1,
+      bundleItems: bundle.items.map((i) => ({
+        id: i.id,
+        name: i.title,
+        price: i.price,
+        imageUrl: i.image,
+        description: i.description,
+      })),
+      isBundle: true,
+    } as any;
+    addToCart(prod);
     toast.success(`Added "${bundle.title}" bundle to cart!`);
   };
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -46,6 +46,10 @@ export interface Product {
   thumbnail: string;
   images: string[];
   reviews?: Review[];
+  /** If this product represents a gift bundle, the bundled items */
+  bundleItems?: GiftItem[];
+  /** Flag to easily identify bundle entries in the cart */
+  isBundle?: boolean;
 }
 
 export interface GiftItem {


### PR DESCRIPTION
## Summary
- allow `Product` to mark bundle items and store bundled contents
- add bundle-aware `ProductWithQty` type in cart context
- create bundle cart items when adding from Gift Genius and from bundle customizer page
- display bundle contents and customize option in cart

## Testing
- `npm install`
- `npm test --silent` *(fails: Jest encountered unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_686b6d1228248321b1cfec7f08885256