### PR TITLE
Add ReorderTimeline component with mock logs

### DIFF
--- a/frontend/src/components/ReorderTimeline.tsx
+++ b/frontend/src/components/ReorderTimeline.tsx
@@ -1,0 +1,118 @@
+import React, { useState } from 'react';
+
+export interface ReorderLog {
+  id: string;
+  itemName: string;
+  quantity: number;
+  status: 'suggested' | 'confirmed' | 'skipped' | 'delayed';
+  date: string; // ISO string
+}
+
+const mockReorderLogs: ReorderLog[] = [
+  {
+    id: '1',
+    itemName: 'Milk',
+    quantity: 1000,
+    status: 'suggested',
+    date: '2025-07-06T10:15:00Z',
+  },
+  {
+    id: '2',
+    itemName: 'Rice',
+    quantity: 2000,
+    status: 'confirmed',
+    date: '2025-07-05T18:45:00Z',
+  },
+  {
+    id: '3',
+    itemName: 'Eggs',
+    quantity: 12,
+    status: 'skipped',
+    date: '2025-07-04T08:30:00Z',
+  },
+  {
+    id: '4',
+    itemName: 'Coffee Beans',
+    quantity: 500,
+    status: 'delayed',
+    date: '2025-07-03T14:20:00Z',
+  },
+];
+
+const statusColors: Record<ReorderLog['status'], string> = {
+  suggested: 'bg-yellow-500',
+  confirmed: 'bg-green-600',
+  skipped: 'bg-red-600',
+  delayed: 'bg-orange-500',
+};
+
+const statusLabels: Record<ReorderLog['status'], string> = {
+  suggested: 'Suggested',
+  confirmed: 'Confirmed',
+  skipped: 'Skipped',
+  delayed: 'Delayed',
+};
+
+const filters: Array<'all' | ReorderLog['status']> = [
+  'all',
+  'suggested',
+  'confirmed',
+  'skipped',
+  'delayed',
+];
+
+const ReorderTimeline: React.FC = () => {
+  const [filter, setFilter] = useState<typeof filters[number]>('all');
+
+  const logs = [...mockReorderLogs]
+    .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
+    .filter((log) => filter === 'all' || log.status === filter);
+
+  return (
+    <div className="space-y-4">
+      <div className="flex gap-2 mb-2">
+        {filters.map((f) => (
+          <button
+            key={f}
+            onClick={() => setFilter(f)}
+            className={`px-3 py-1 rounded-md text-sm font-medium transition-colors ${
+              filter === f
+                ? 'bg-primary-500 text-white'
+                : 'bg-gray-200 dark:bg-gray-700 text-gray-900 dark:text-gray-100'
+            }`}
+          >
+            {f === 'all' ? 'All' : statusLabels[f]}
+          </button>
+        ))}
+      </div>
+      <ul className="space-y-4">
+        {logs.map((log) => (
+          <li key={log.id} className="relative pl-6">
+            <div className="absolute left-0 top-1.5 w-3 h-3 rounded-full bg-primary-500" />
+            <div className="flex items-start justify-between bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-md p-3">
+              <div>
+                <p className="font-medium text-gray-900 dark:text-white">
+                  {log.itemName}
+                </p>
+                <p className="text-sm text-gray-500">
+                  Qty: {log.quantity} –{' '}
+                  {new Date(log.date).toLocaleString(undefined, {
+                    dateStyle: 'medium',
+                    timeStyle: 'short',
+                  })}
+                </p>
+              </div>
+              <span
+                className={`text-xs font-medium text-white px-2 py-1 rounded ${statusColors[log.status]}`}
+              >
+                {statusLabels[log.status]}
+              </span>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default ReorderTimeline;

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,10 +1,15 @@
 import React from 'react';
 import PantryDashboard from '../components/PantryDashboard';
+import ReorderTimeline from '../components/ReorderTimeline';
 
 const Dashboard: React.FC = () => (
   <div className="p-4">
     <h1 className="text-2xl font-bold mb-4">SmartPantry Dashboard</h1>
     <PantryDashboard />
+    <div className="mt-8">
+      <h2 className="text-xl font-semibold mb-2">Reorder Timeline</h2>
+      <ReorderTimeline />
+    </div>
   </div>
 );
 


### PR DESCRIPTION
## Summary
- implement `ReorderTimeline` to show SmartPantry reorder events
- add reorder timeline to the Dashboard

## Testing
- `npm install`
- `npm test -- --watchAll=false` *(fails: SyntaxError in axios)*

------
https://chatgpt.com/codex/tasks/task_e_686b70e3c6bc8321bfe3cfc7778d0138