### PR TITLE
Add pantry streak tracker component

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,9 +1,19 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import App from './App';
+import { AuthProvider } from './context/AuthContext';
+
+// Mock axios to avoid ESM parsing issues during tests
+jest.mock('axios', () => ({
+  create: () => ({ get: jest.fn(), post: jest.fn() }),
+}));
 
 test('renders SmartPantry text somewhere', () => {
-  render(<App />);
+  render(
+    <AuthProvider>
+      <App />
+    </AuthProvider>
+  );
   const elements = screen.getAllByText(/SmartPantry/i);
   expect(elements.length).toBeGreaterThan(0);
 });

--- a/frontend/src/components/StreakTracker.test.tsx
+++ b/frontend/src/components/StreakTracker.test.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import StreakTracker, { PantryItem } from './StreakTracker';
+
+describe('StreakTracker', () => {
+  it('displays correct streak length', () => {
+    jest.spyOn(Date, 'now').mockReturnValue(new Date('2024-01-10').getTime());
+    const items: PantryItem[] = [
+      { name: 'Milk', quantity: 2, dailyConsumptionRate: 1, lastDepletedDate: '2024-01-05' },
+      { name: 'Eggs', quantity: 5, dailyConsumptionRate: 1, lastDepletedDate: '2024-01-03' }
+    ];
+    render(<StreakTracker pantryItems={items} />);
+    expect(screen.getByText('5')).toBeInTheDocument();
+    (Date.now as jest.Mock).mockRestore();
+  });
+});

--- a/frontend/src/components/StreakTracker.tsx
+++ b/frontend/src/components/StreakTracker.tsx
@@ -1,0 +1,43 @@
+import React, { useMemo } from 'react';
+
+export interface PantryItem {
+  name: string;
+  quantity: number;
+  dailyConsumptionRate: number;
+  lastDepletedDate?: string;
+}
+
+interface Props {
+  pantryItems: PantryItem[];
+}
+
+const StreakTracker: React.FC<Props> = ({ pantryItems }) => {
+  const streakDays = useMemo(() => {
+    let latest: Date | null = null;
+    pantryItems.forEach((item) => {
+      if (item.quantity <= 0 && !item.lastDepletedDate) {
+        latest = new Date();
+        return;
+      }
+      if (item.lastDepletedDate) {
+        const date = new Date(item.lastDepletedDate);
+        if (!latest || date > latest) {
+          latest = date;
+        }
+      }
+    });
+
+    if (!latest) return 0;
+    const diff = Date.now() - latest.getTime();
+    return Math.max(0, Math.floor(diff / (1000 * 60 * 60 * 24)));
+  }, [pantryItems]);
+
+  return (
+    <div className="bg-white dark:bg-gray-800 rounded-lg shadow p-4 flex flex-col items-center">
+      <span className="text-2xl font-semibold text-primary-600">{streakDays}</span>
+      <span className="text-sm text-gray-500">Day Streak</span>
+    </div>
+  );
+};
+
+export default StreakTracker;


### PR DESCRIPTION
## Summary
- add a StreakTracker component with streak calculation
- test StreakTracker component
- mock axios and provide AuthProvider in App.test

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_686b7172c6c48321a77e2a8d46e11042