### PR TITLE
Fix profile page auth handling

### DIFF
--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -58,12 +58,14 @@ const Navbar: React.FC = () => {
                   Login
                 </Link>
               )}
-              <Link
-                to="/profile"
-                className="px-3 py-2 rounded-md text-sm font-medium hover:bg-primary-500 hover:text-accent-300 transition-all"
-              >
-                Profile
-              </Link>
+              {isAuthenticated && (
+                <Link
+                  to="/profile"
+                  className="px-3 py-2 rounded-md text-sm font-medium hover:bg-primary-500 hover:text-accent-300 transition-all"
+                >
+                  Profile
+                </Link>
+              )}
             </div>
           </div>
           <div className="-mr-2 flex md:hidden">
@@ -133,13 +135,15 @@ const Navbar: React.FC = () => {
               Login
             </Link>
           )}
-          <Link
-            to="/profile"
-            className="block px-3 py-2 rounded-md text-base font-medium hover:bg-primary-500 hover:text-accent-300 transition-all"
-            onClick={() => setIsOpen(false)}
-          >
-            Profile
-          </Link>
+          {isAuthenticated && (
+            <Link
+              to="/profile"
+              className="block px-3 py-2 rounded-md text-base font-medium hover:bg-primary-500 hover:text-accent-300 transition-all"
+              onClick={() => setIsOpen(false)}
+            >
+              Profile
+            </Link>
+          )}
         </div>
       )}
     </nav>

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -19,10 +19,11 @@ const ProfilePage: React.FC = () => {
   const [autoOrder, setAutoOrder] = useState<boolean>(false);
   const [loading, setLoading] = useState<boolean>(true);
   const navigate = useNavigate();
-  const { session, user } = useAuth();
+  const { session, user, loading: authLoading } = useAuth();
 
   useEffect(() => {
     const loadProfile = async () => {
+      if (authLoading) return;
       if (!session || !user) {
         navigate('/login');
         return;
@@ -61,7 +62,7 @@ const ProfilePage: React.FC = () => {
     };
 
     loadProfile();
-  }, [navigate, session, user]);
+  }, [navigate, session, user, authLoading]);
 
   const toggleAutoOrder = async () => {
     if (!profile) return;


### PR DESCRIPTION
## Summary
- ensure auth context exposes a loading state
- block redirects until auth loading completes
- show profile link only when logged in

## Testing
- `npm test -- --watchAll=false`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_686b9f873904832192103a6d125ba424