### PR TITLE
Update pantry setup terminology and units

### DIFF
--- a/frontend/src/components/PantryItemCard.tsx
+++ b/frontend/src/components/PantryItemCard.tsx
@@ -13,7 +13,7 @@ const PantryItemCard: React.FC<Props> = ({ item, onEdit, onDelete }) => {
       <div>
         <p className="font-medium text-gray-900 dark:text-white">{item.name}</p>
         <p className="text-sm text-gray-500 dark:text-gray-400">
-          {item.rate} every {item.days}d - reorder at {item.reorderBuffer}% ({item.category})
+          {item.category} – Daily Use: {item.rate} {item.unit} – Duration: {item.days} {item.days === 1 ? 'day' : 'days'} – Reorder Buffer: {item.reorderBuffer}%
         </p>
       </div>
       <div className="space-x-2">

--- a/frontend/src/components/ReorderTimeline.tsx
+++ b/frontend/src/components/ReorderTimeline.tsx
@@ -4,6 +4,7 @@ export interface ReorderLog {
   id: string;
   itemName: string;
   quantity: number;
+  unit?: string;
   status: 'suggested' | 'confirmed' | 'skipped' | 'delayed';
   date: string; // ISO string
 }
@@ -13,6 +14,7 @@ const mockReorderLogs: ReorderLog[] = [
     id: '1',
     itemName: 'Milk',
     quantity: 1000,
+    unit: 'ml',
     status: 'suggested',
     date: '2025-07-06T10:15:00Z',
   },
@@ -20,6 +22,7 @@ const mockReorderLogs: ReorderLog[] = [
     id: '2',
     itemName: 'Rice',
     quantity: 2000,
+    unit: 'g',
     status: 'confirmed',
     date: '2025-07-05T18:45:00Z',
   },
@@ -27,6 +30,7 @@ const mockReorderLogs: ReorderLog[] = [
     id: '3',
     itemName: 'Eggs',
     quantity: 12,
+    unit: 'pcs',
     status: 'skipped',
     date: '2025-07-04T08:30:00Z',
   },
@@ -34,6 +38,7 @@ const mockReorderLogs: ReorderLog[] = [
     id: '4',
     itemName: 'Coffee Beans',
     quantity: 500,
+    unit: 'g',
     status: 'delayed',
     date: '2025-07-03T14:20:00Z',
   },
@@ -141,7 +146,7 @@ const ReorderTimeline: React.FC = () => {
                         {new Date(log.date).toLocaleString(undefined, {
                           dateStyle: 'medium',
                           timeStyle: 'short',
-                        })} • Qty: {log.quantity}
+                        })} • Qty: {log.quantity} {log.unit || ''}
                       </p>
                     </div>
                     <span


### PR DESCRIPTION
## Summary
- add helper for inferring units in PantrySetup
- include `unit` in PantryItem state and update form labels
- allow selecting measurement units when adding items
- display units in PantryItemCard
- show units in ReorderTimeline mock data

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687390800208832184b8bfe1532c9aeb